### PR TITLE
Add "repl" support to "tsrun"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,12 @@ jobs:
         run: |
           VERSION="$(node -p 'require("./package.json").version')"
 
+          test -z "$(git ls-remote --tags origin v0.2.123)" || {
+            echo "Release ${VERSION} already tagged, exiting..."
+            echo "::notice::Release ${VERSION} already tagged"
+            exit 0
+          }
+
           git config user.email 'developers@juit.com'
           git config user.name 'Github Workflows'
           git tag -a -m "v${VERSION}" "v${VERSION}" "${{ github.sha }}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,9 @@ cd "$(dirname $0)"
 # Remove whatever was bootstrapped
 rm -rf ./bootstrap
 
+# Get the version for the command line
+VERSION="$(node -p 'require("./workspaces/plug/package.json").version')"
+
 # Compile our "ts-loader" loader and CLI
 exec ./node_modules/.bin/esbuild \
 	--platform=node \
@@ -16,6 +19,7 @@ exec ./node_modules/.bin/esbuild \
 	--sources-content=false \
 	--out-extension:.js=.mjs \
 	--external:esbuild \
+	--define:__version="'${VERSION}'" \
 	--bundle \
 		./workspaces/plug/extra/*.mts
 

--- a/build.ts
+++ b/build.ts
@@ -8,10 +8,10 @@ import {
   find,
   fixExtensions,
   fork,
-  fs,
   log,
   merge,
   paths,
+  parseJson,
   resolve,
   rmrf,
 } from './workspaces/plug/src/index'
@@ -152,6 +152,8 @@ export default build({
 
   /** Transpile CLI */
   async transpile_cli(): Promise<Files> {
+    const version = parseJson('package.json').version
+
     // then we *only check* the types for "workspaces/plug/extra"
     log.notice(`Checking extras types sanity in ${$p(resolve('workspaces/plug/extra'))}`)
     await find('**/*.([cm])?ts', { directory: 'workspaces/plug/extra' })
@@ -174,6 +176,7 @@ export default build({
           sourcesContent: false,
           external: [ 'esbuild' ],
           outExtension: { '.js': '.mjs' },
+          define: { '__version': JSON.stringify(version) },
           outdir: 'workspaces/plug/cli',
         })
   },
@@ -318,8 +321,7 @@ export default build({
 
   /* Prepare exports in our "package.json" files */
   async exports(): Promise<void> {
-    const data = await fs.readFile(resolve('package.json'), 'utf-8')
-    const version = JSON.parse(data).version
+    const version = parseJson('package.json').version
 
     banner(`Updating package.json files (version=${version})`)
 

--- a/workspaces/plug/extra/plug.mts
+++ b/workspaces/plug/extra/plug.mts
@@ -6,10 +6,13 @@ import _path from 'node:path'
 
 import _yargs from 'yargs-parser'
 
-import { $blu, $gry, $rst, $tsk, $und, $wht, isDirectory, isFile, main, version } from './utils.js'
+import { $blu, $gry, $rst, $tsk, $und, $wht, isDirectory, isFile, main } from './utils.js'
 
 import type { BuildFailure } from '../src/asserts.js'
 import type { Build } from '../src/index.js'
+
+/** Version injected by esbuild */
+declare const __version: string
 
 /* ========================================================================== *
  * ========================================================================== *
@@ -123,7 +126,7 @@ export function parseCommandLine(args: string[]): CommandLineOptions {
         help = !! value
         break
       case 'version':
-        console.log(`v${version()}`)
+        console.log(`v${__version}`)
         process.exit(0)
         break
       default:
@@ -151,7 +154,7 @@ export function parseCommandLine(args: string[]): CommandLineOptions {
         ${$wht}-c --colors${$rst}     Force colorful output (use "--no-colors" to force plain text)
         ${$wht}-l --list${$rst}       Only list the tasks defined by the build, nothing more!
         ${$wht}-h --help${$rst}       Help! You're reading it now!
-        ${$wht}   --version${$rst}    Version! This one: ${version()}!
+        ${$wht}   --version${$rst}    Version! This one: ${__version}!
 
     ${$blu}${$und}Properties:${$rst}
 

--- a/workspaces/plug/extra/utils.ts
+++ b/workspaces/plug/extra/utils.ts
@@ -18,24 +18,6 @@ export const $tsk = process.stdout.isTTY ? '\u001b[38;5;141m' : '' // the color 
 
 
 /* ========================================================================== *
- * PACKAGE VERSION                                                            *
- * ========================================================================== */
-
-export function version(): string {
-  const debug = _util.debuglog('plug:cli')
-
-  try {
-    const thisFile = _url.fileURLToPath(import.meta.url)
-    const packageFile = _path.resolve(thisFile, '..', '..', 'package.json')
-    const packageData = _fs.readFileSync(packageFile, 'utf-8')
-    return JSON.parse(packageData).version || '(unknown)'
-  } catch (error) {
-    debug('Error parsing version:', error)
-    return '(error)'
-  }
-}
-
-/* ========================================================================== *
  * TS LOADER FORCE TYPE                                                       *
  * ========================================================================== */
 

--- a/workspaces/plug/src/helpers.ts
+++ b/workspaces/plug/src/helpers.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -206,4 +206,27 @@ export function exec(
 ): Promise<void> {
   const { params, options } = parseOptions(args)
   return execChild(cmd, params, options, requireContext())
+}
+
+/**
+ * Read and parse a JSON file, throwing an error if not found.
+ *
+ * @params file The JSON file to parse
+ */
+export function parseJson(file: string): any {
+  const jsonFile = requireContext().resolve(file)
+  let jsonText: string
+  try {
+    jsonText = readFileSync(jsonFile, 'utf-8')
+  } catch (error: any) {
+    if (error.code === 'ENOENT') log.fail(`File ${$p(jsonFile)} not found`)
+    if (error.code === 'EACCES') log.fail(`File ${$p(jsonFile)} can not be accessed`)
+    log.fail(`Error reading ${$p(jsonFile)}`, error)
+  }
+
+  try {
+    return JSON.parse(jsonText)
+  } catch (error) {
+    log.fail(`Error parsing ${$p(jsonFile)}`, error)
+  }
 }

--- a/workspaces/plug/src/utils/exec.ts
+++ b/workspaces/plug/src/utils/exec.ts
@@ -90,13 +90,13 @@ export async function execChild(
   // Standard output to "notice"
   if (child.stdout) {
     const out = reaadline.createInterface(child.stdout)
-    out.on('line', (line) => line ? context.log.notice(line) : context.log.notice('\u00a0'))
+    out.on('line', (line) => context.log.notice(line || '\u00a0'))
   }
 
   // Standard error to "warning"
   if (child.stderr) {
     const err = reaadline.createInterface(child.stderr)
-    err.on('line', (line) => line ? context.log.warn(line) : context.log.warn('\u00a0'))
+    err.on('line', (line) => context.log.warn(line ||'\u00a0'))
   }
 
   // Return our promise from the spawn events


### PR DESCRIPTION
Now `tsrun` supports `--eval` and `--print` for quick command line requests, and starts the `repl` if launched without a script.