### PR TITLE
Improve expectations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plugjs/monorepo",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plugjs/monorepo",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "workspaces": [
         "workspaces/cov8",
         "workspaces/eslint",
@@ -496,9 +496,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.0.tgz",
-      "integrity": "sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -607,17 +607,17 @@
       }
     },
     "node_modules/@pkgr/utils": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.3.1.tgz",
-      "integrity": "sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-2OCURAmRtdlL8iUDTypMrrxfwe8frXTeXaxGsVOaYtc/wrUyk8Z/0OBetM7cdlsy7ZFWlMX72VogKeh+A4Xcjw==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.2.12",
         "is-glob": "^4.0.3",
-        "open": "^8.4.0",
+        "open": "^9.1.0",
         "picocolors": "^1.0.0",
-        "tiny-glob": "^0.2.9",
-        "tslib": "^2.4.0"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
@@ -697,9 +697,9 @@
       "integrity": "sha512-YQi2lvZSI+xidKeUjlbv6b6Zw7qB3aXHw5oGJLs5OOGAEqKIOvz5UIAkWyg0bJbkSUWPBEtaOHpVxU4EYBO1Jg=="
     },
     "node_modules/@types/chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "node_modules/@types/eslint": {
@@ -734,9 +734,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.16.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.2.tgz",
-      "integrity": "sha512-GQW/JL/5Fz/0I8RpeBG9lKp0+aNcXEaVL71c0D2Q0QHDTFvlYKT7an0onCUXj85anv7b4/WesqdfchLc0jtsCg=="
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -775,16 +775,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.1.tgz",
-      "integrity": "sha512-AVi0uazY5quFB9hlp2Xv+ogpfpk77xzsgsIEWyVS7uK/c7MZ5tw7ZPbapa0SbfkqE0fsAMkz5UwtgMLVk2BQAg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
+      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/type-utils": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/type-utils": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -810,15 +810,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.1.tgz",
-      "integrity": "sha512-nzjFAN8WEu6yPRDizIFyzAfgK7nybPodMNFGNH0M9tei2gYnYszRDqVA0xlnRjkl7Hkx2vYrEdb6fP2a21cG1g==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -838,14 +838,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.1.tgz",
-      "integrity": "sha512-mau0waO5frJctPuAzcxiNWqJR5Z8V0190FTSqRw1Q4Euop6+zTwHAf8YIXNwDOT29tyUDrQ65jSg9aTU/H0omA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -856,14 +856,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.1.tgz",
-      "integrity": "sha512-ZMWQ+Oh82jWqWzvM3xU+9y5U7MEMVv6GLioM3R5NJk6uvP47kZ7YvlgSHJ7ERD6bOY7Q4uxWm25c76HKEwIjZw==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
+      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.1",
-        "@typescript-eslint/utils": "5.59.1",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.1.tgz",
-      "integrity": "sha512-dg0ICB+RZwHlysIy/Dh1SP+gnXNzwd/KS0JprD3Lmgmdq+dJAJnUPe1gNG34p0U19HvRlGX733d/KqscrGC1Pg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -898,14 +898,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.1.tgz",
-      "integrity": "sha512-lYLBBOCsFltFy7XVqzX0Ju+Lh3WPIAWxYpmH/Q7ZoqzbscLiCW00LeYCdsUnnfnj29/s1WovXKh2gwCoinHNGA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/visitor-keys": "5.59.1",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -926,18 +926,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.1.tgz",
-      "integrity": "sha512-MkTe7FE+K1/GxZkP5gRj3rCztg45bEhsd8HYjczBuYm+qFHP5vtZmjx3B0yUCDotceQ4sHgTyz60Ycl225njmA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
+      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.1",
-        "@typescript-eslint/types": "5.59.1",
-        "@typescript-eslint/typescript-estree": "5.59.1",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -953,13 +953,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.1.tgz",
-      "integrity": "sha512-6waEYwBTCWryx0VJmP7JaM4FpipLsFl9CvYf2foAE8Qh/Y0s+bxWysciwOs0LTBED4JCaNxTZ5rGadB14M6dwA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.1",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1166,6 +1166,27 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1201,6 +1222,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1427,13 +1463,50 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -2061,6 +2134,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
+      "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2242,6 +2338,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
@@ -2326,12 +2434,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/globalyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-      "dev": true
-    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -2350,12 +2452,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -2471,6 +2567,15 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+    },
+    "node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2648,15 +2753,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2687,6 +2792,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-negative-zero": {
@@ -2766,6 +2889,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -2850,6 +2985,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3100,6 +3250,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3118,6 +3274,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -3197,6 +3365,33 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -3258,18 +3453,34 @@
         "wrappy": "1"
       }
     },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dev": true,
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
+        "mimic-fn": "^4.0.0"
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3626,9 +3837,9 @@
       }
     },
     "node_modules/regexp-tree": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.25.tgz",
-      "integrity": "sha512-szcL3aqw+vEeuxhL1AMYRyeMP+goYF5I/guaH10uJX5xbGyeQeNPPneaj3ZWVmGLCDxrVaaYekkr5R12gk4dJw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
       "dev": true,
       "bin": {
         "regexp-tree": "bin/regexp-tree"
@@ -3717,6 +3928,110 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/run-applescript/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/run-applescript/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/run-applescript/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/run-applescript/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/run-parallel": {
@@ -3810,6 +4125,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -3933,6 +4254,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4019,14 +4352,16 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
-    "node_modules/tiny-glob": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+    "node_modules/titleize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true,
-      "dependencies": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/to-fast-properties": {
@@ -4189,6 +4524,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4313,7 +4657,7 @@
     },
     "workspaces/cov8": {
       "name": "@plugjs/cov8",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.21.5",
@@ -4325,12 +4669,12 @@
         "cov8": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.6"
+        "@plugjs/plug": "0.4.7"
       }
     },
     "workspaces/eslint": {
       "name": "@plugjs/eslint",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint": "^8.39.0"
@@ -4339,27 +4683,27 @@
         "@types/eslint": "^8.37.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.6"
+        "@plugjs/plug": "0.4.7"
       }
     },
     "workspaces/expect5": {
       "name": "@plugjs/expect5",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "bin": {
         "expect5": "dist/cli.mjs"
       },
       "devDependencies": {
-        "@types/chai": "^4.3.4",
+        "@types/chai": "^4.3.5",
         "chai": "^4.3.7"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.6"
+        "@plugjs/plug": "0.4.7"
       }
     },
     "workspaces/plug": {
       "name": "@plugjs/plug",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@plugjs/tsrun": "^0.4.1",
@@ -4376,29 +4720,29 @@
     },
     "workspaces/tsd": {
       "name": "@plugjs/tsd",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "tsd": "^0.28.1"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.6"
+        "@plugjs/plug": "0.4.7"
       }
     },
     "workspaces/typescript": {
       "name": "@plugjs/typescript",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.6"
+        "@plugjs/plug": "0.4.7"
       }
     },
     "workspaces/zip": {
       "name": "@plugjs/zip",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "license": "Apache-2.0",
       "dependencies": {
         "yazl": "^2.5.1"
@@ -4409,7 +4753,7 @@
         "yauzl": "^2.10.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.6"
+        "@plugjs/plug": "0.4.7"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plugjs/monorepo",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "workspaces": [
     "workspaces/cov8",

--- a/test-d/11-expect5-expectations.test-d.ts
+++ b/test-d/11-expect5-expectations.test-d.ts
@@ -62,6 +62,7 @@ expectType<Expectations<bigint>>(expectations.toBeGreaterThanOrEqual(10n))
 /* === TO BE INSTANCE OF ==================================================== */
 
 expectType<Expectations<TestError>>(expectations.toBeInstanceOf(TestError))
+expectType<Expectations<TestError & { length: number }>>(expectations.toBeInstanceOf(TestError, expect.toHaveLength(12)))
 expectType<Expectations<number>>(expectations.toBeInstanceOf(TestError, (assert) => assert.toBeA('number')))
 expectType<Expectations<TestError>>(expectations.toBeInstanceOf(TestError, (assert) => {
   expectType<Expectations<TestError>>(assert)

--- a/test-d/11-expect5-expectations.test-d.ts
+++ b/test-d/11-expect5-expectations.test-d.ts
@@ -123,8 +123,16 @@ expectType<Expectations<TestType & { length: number }>>(expectations.toHaveLengt
 /* === TO HAVE PROPERTY ===================================================== */
 
 expect<Expectations<TestType & { prop: unknown }>>(expectations.toHaveProperty('prop'))
+
+// with matchers
+expect<Expectations<TestType & { prop: number }>>(expectations.toHaveProperty('prop', expect.toBeA('number')))
+expect<Expectations<TestType & { prop: { foo: string } }>>(expectations.toHaveProperty('prop', expect.toEqual({ foo: 'bar' })))
+
+// with assertions
 expect<Expectations<TestType & { prop: number }>>(expectations.toHaveProperty('prop', (assert) => assert.toBeA('number')))
 expect<Expectations<TestType & { prop: undefined }>>(expectations.toHaveProperty('prop', (assert) => assert.toBeUndefined()))
+
+// with assertion returning "void"
 expect<Expectations<TestType & { prop: unknown }>>(expectations.toHaveProperty('prop', (assert) => {
   expectType<Expectations<unknown>>(assert)
   assert.toBeA('number')

--- a/test-d/11-expect5-expectations.test-d.ts
+++ b/test-d/11-expect5-expectations.test-d.ts
@@ -15,6 +15,8 @@ expectType<TestType>(expectations.value)
 /* === TO BE A ============================================================== */
 
 expectType<Expectations<string>>(expectations.toBeA('string'))
+expectType<Expectations<never>>(expectations.toBeA('string', expect.toBeA('number'))) // string & number
+expectType<Expectations<string & { length: number }>>(expectations.toBeA('string', expect.toHaveLength(12)))
 expectType<Expectations<number>>(expectations.toBeA('string', (assert) => assert.toBeA('number')))
 expectType<Expectations<string>>(expectations.toBeA('string', (assert) => {
   expectType<Expectations<string>>(assert)

--- a/test-d/11-expect5-expectations.test-d.ts
+++ b/test-d/11-expect5-expectations.test-d.ts
@@ -169,6 +169,7 @@ expectType<Expectations<{ foo: string}>>(expectations.toStrictlyEqual({ foo: 'ba
 /* === TO THROW ============================================================= */
 
 expectType<Expectations<() => any>>(expectations.toThrow())
+expectType<Expectations<() => any>>(expectations.toThrow(expect.toBeA('string')))
 expectType<Expectations<() => any>>(expectations.toThrow((assert) => assert.toBeA('string')))
 expectType<Expectations<() => any>>(expectations.toThrow((assert) => {
   expectType<Expectations<unknown>>(assert)

--- a/test-d/11-expect5-expectations.test-d.ts
+++ b/test-d/11-expect5-expectations.test-d.ts
@@ -126,7 +126,7 @@ expect<Expectations<TestType & { prop: unknown }>>(expectations.toHaveProperty('
 
 // with matchers
 expect<Expectations<TestType & { prop: number }>>(expectations.toHaveProperty('prop', expect.toBeA('number')))
-expect<Expectations<TestType & { prop: { foo: string } }>>(expectations.toHaveProperty('prop', expect.toEqual({ foo: 'bar' })))
+expect<Expectations<TestType & { prop: { foo: string } }>>(expectations.toHaveProperty('prop', expect.toEqual({ foo: expect.toBeA('string') })))
 
 // with assertions
 expect<Expectations<TestType & { prop: number }>>(expectations.toHaveProperty('prop', (assert) => assert.toBeA('number')))

--- a/test-d/13-expect5-matchers.test-d.ts
+++ b/test-d/13-expect5-matchers.test-d.ts
@@ -121,8 +121,16 @@ expectType<Matchers<unknown & { length: number }>>(expect.toHaveLength(123))
 /* === TO HAVE PROPERTY ===================================================== */
 
 expect<Matchers<unknown & { prop: unknown }>>(expect.toHaveProperty('prop'))
+
+// with matchers
+expect<Matchers<unknown & { prop: number }>>(expect.toHaveProperty('prop', expect.toBeA('number')))
+expect<Matchers<unknown & { prop: { foo: string } }>>(expect.toHaveProperty('prop', expect.toEqual({ foo: 'bar' })))
+
+// with assertions
 expect<Matchers<unknown & { prop: number }>>(expect.toHaveProperty('prop', (assert) => assert.toBeA('number')))
 expect<Matchers<unknown & { prop: undefined }>>(expect.toHaveProperty('prop', (assert) => assert.toBeUndefined()))
+
+// with assertion returning "void"
 expect<Matchers<unknown & { prop: unknown }>>(expect.toHaveProperty('prop', (assert) => {
   expectType<Expectations<unknown>>(assert)
   assert.toBeA('number')

--- a/test-d/13-expect5-matchers.test-d.ts
+++ b/test-d/13-expect5-matchers.test-d.ts
@@ -13,6 +13,8 @@ expectType<string>(expect.toBeA('string').expect(12345))
 /* === TO BE A ============================================================== */
 
 expectType<Matchers<string>>(expect.toBeA('string'))
+expectType<Matchers<never>>(expect.toBeA('string', expect.toBeA('number')))
+expectType<Matchers<string & { length: number }>>(expect.toBeA('string', expect.toHaveLength(12)))
 expectType<Matchers<number>>(expect.toBeA('string', (assert) => assert.toBeA('number')))
 expectType<Matchers<string>>(expect.toBeA('string', (assert) => {
   expectType<Expectations<string>>(assert)

--- a/test-d/13-expect5-matchers.test-d.ts
+++ b/test-d/13-expect5-matchers.test-d.ts
@@ -60,6 +60,7 @@ expectType<Matchers<bigint>>(expect.toBeGreaterThanOrEqual(10n))
 /* === TO BE INSTANCE OF ==================================================== */
 
 expectType<Matchers<TestError>>(expect.toBeInstanceOf(TestError))
+expectType<Matchers<TestError & { length: number }>>(expect.toBeInstanceOf(TestError, expect.toHaveLength(12)))
 expectType<Matchers<number>>(expect.toBeInstanceOf(TestError, (assert) => assert.toBeA('number')))
 expectType<Matchers<TestError>>(expect.toBeInstanceOf(TestError, (assert) => {
   expectType<Expectations<TestError>>(assert)

--- a/test-d/19-expect5-async.test-d.ts
+++ b/test-d/19-expect5-async.test-d.ts
@@ -30,6 +30,26 @@ expectType<Promise<Expectations<PromiseLike<boolean>>>>(
 
 /* -------------------------------------------------------------------------- */
 
+// toBeRejected(matcher)
+
+expectType<Promise<Expectations<PromiseLike<unknown>>>>(
+    expect(unknown).toBeRejected(expect.toBeInstanceOf(Error)),
+)
+
+expectType<Promise<Expectations<PromiseLike<unknown>>>>(
+    expect(Promise.resolve(unknown)).toBeRejected(expect.toBeInstanceOf(Error)),
+)
+
+expectType<Promise<Expectations<PromiseLike<boolean>>>>(
+    expect(true).toBeRejected(expect.toBeInstanceOf(Error)),
+)
+
+expectType<Promise<Expectations<PromiseLike<boolean>>>>(
+    expect(Promise.resolve(true)).toBeRejected(expect.toBeInstanceOf(Error)),
+)
+
+/* -------------------------------------------------------------------------- */
+
 // toBeRejected(assert) - assert returns void
 
 expectType<Promise<Expectations<PromiseLike<unknown>>>>(
@@ -57,6 +77,38 @@ expectType<Promise<Expectations<PromiseLike<boolean>>>>(
     expect(Promise.resolve(true)).toBeRejected((assert) => {
       expectType<Expectations<unknown>>(assert) // unknown, it's a rejection!
       // return void
+    }),
+)
+
+/* -------------------------------------------------------------------------- */
+
+// toBeRejected(assert) - assert returns Expectations<string>
+
+expectType<Promise<Expectations<PromiseLike<unknown>>>>(
+    expect(unknown).toBeRejected((assert) => {
+      expectType<Expectations<unknown>>(assert) // unknown, it's a rejection!
+      return assert.toBeA('string')
+    }),
+)
+
+expectType<Promise<Expectations<PromiseLike<unknown>>>>(
+    expect(Promise.resolve(unknown)).toBeRejected((assert) => {
+      expectType<Expectations<unknown>>(assert) // unknown, it's a rejection!
+      return assert.toBeA('string')
+    }),
+)
+
+expectType<Promise<Expectations<PromiseLike<boolean>>>>(
+    expect(true).toBeRejected((assert) => {
+      expectType<Expectations<unknown>>(assert) // unknown, it's a rejection!
+      return assert.toBeA('string')
+    }),
+)
+
+expectType<Promise<Expectations<PromiseLike<boolean>>>>(
+    expect(Promise.resolve(true)).toBeRejected((assert) => {
+      expectType<Expectations<unknown>>(assert) // unknown, it's a rejection!
+      return assert.toBeA('string')
     }),
 )
 
@@ -166,6 +218,26 @@ expectType<Promise<Expectations<PromiseLike<boolean>>>>(
 
 expectType<Promise<Expectations<PromiseLike<boolean>>>>(
     expect(Promise.resolve(true)).toBeResolved(),
+)
+
+/* -------------------------------------------------------------------------- */
+
+// toBeResolved(matcher)
+
+expectType<Promise<Expectations<PromiseLike<string>>>>(
+    expect(unknown).toBeResolved(expect.toBeA('string')),
+)
+
+expectType<Promise<Expectations<PromiseLike<string>>>>(
+    expect(Promise.resolve(unknown)).toBeResolved(expect.toBeA('string')),
+)
+
+expectType<Promise<Expectations<PromiseLike<string>>>>(
+    expect(true).toBeResolved(expect.toBeA('string')),
+)
+
+expectType<Promise<Expectations<PromiseLike<string>>>>(
+    expect(Promise.resolve(true)).toBeResolved(expect.toBeA('string')),
 )
 
 /* -------------------------------------------------------------------------- */

--- a/workspaces/cov8/package.json
+++ b/workspaces/cov8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/cov8",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -39,7 +39,7 @@
     "source-map": "^0.7.4"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.6"
+    "@plugjs/plug": "0.4.7"
   },
   "files": [
     "*.md",

--- a/workspaces/eslint/package.json
+++ b/workspaces/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/eslint",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -36,7 +36,7 @@
     "@types/eslint": "^8.37.0"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.6"
+    "@plugjs/plug": "0.4.7"
   },
   "files": [
     "*.md",

--- a/workspaces/expect5/package.json
+++ b/workspaces/expect5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/expect5",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -43,11 +43,11 @@
   "author": "Juit Developers <developers@juit.com>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/chai": "^4.3.4",
+    "@types/chai": "^4.3.5",
     "chai": "^4.3.7"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.6"
+    "@plugjs/plug": "0.4.7"
   },
   "files": [
     "*.md",

--- a/workspaces/expect5/src/expectation/async.ts
+++ b/workspaces/expect5/src/expectation/async.ts
@@ -2,7 +2,7 @@ import {
   Expectations,
   type AssertionFunction,
   type AssertedType,
-  type InferMatchers,
+  type InferToEqual,
 } from './expectations'
 
 import type { Constructor } from './types'
@@ -54,7 +54,8 @@ export class AsyncExpectations<T = unknown> extends Expectations<T> {
 
   /**
    * Expects the value to be a {@link PromiseLike} _rejected_ with an
-   * {@link Error} _strictly equal_ to the one specified.
+   * {@link Error} {@link Expectations.toStrictlyEqual _strictly equal_}
+   * to the one specified.
    *
    * Negation: {@link Expectations.toBeResolved `toBeResolved(...)`}
    */
@@ -139,13 +140,13 @@ export class AsyncExpectations<T = unknown> extends Expectations<T> {
 
   /**
    * Expects the value to be a {@link PromiseLike} _resolved_ with a value
-   * _deeply equal_ to the one specified.
+   * {@link Expectations.toEqual _deeply equal_} to the one specified.
    *
    * Negation: {@link Expectations.toBeRejected `toBeRejected(...)`}
    */
   toBeResolvedWith<Type>(
       expected: Type,
-  ): Promise<Expectations<PromiseLike<InferMatchers<Type>>>> {
+  ): Promise<Expectations<PromiseLike<InferToEqual<Type>>>> {
     return this.toBeResolved((assert) => assert.toEqual(expected)) as any
   }
 }

--- a/workspaces/expect5/src/expectation/async.ts
+++ b/workspaces/expect5/src/expectation/async.ts
@@ -3,9 +3,12 @@ import {
   type AssertionFunction,
   type AssertedType,
   type InferToEqual,
+  type InferMatcher,
 } from './expectations'
+import { isMatcher, type Constructor } from './types'
 
-import type { Constructor } from './types'
+import type { Matcher } from './matchers'
+
 
 /**
  * Extension to {@link Expectations} adding support for {@link Promise}s.
@@ -26,15 +29,35 @@ export class AsyncExpectations<T = unknown> extends Expectations<T> {
   /* ------------------------------------------------------------------------ */
 
   /**
-   * Expects the value to be a _rejected_ {@link PromiseLike}, and (if
-   * specified) further asserts the rejection reason with an
-   * {@link AssertionFunction}.
+   * Expects the value to be a _rejected_ {@link PromiseLike}.
+   *
+   * Negation: {@link Expectations.toBeResolved `toBeResolved(...)`}
+   */
+  toBeRejected(): Promise<Expectations<PromiseLike<Awaited<T>>>>
+
+  /**
+   * Expects the value to be a _rejected_ {@link PromiseLike}, and further
+   * validates the rejection with a {@link Matcher}.
    *
    * Negation: {@link Expectations.toBeResolved `toBeResolved(...)`}
    */
   toBeRejected(
-      assertion?: AssertionFunction,
-  ): Promise<Expectations<PromiseLike<Awaited<T>>>> {
+    matcher: Matcher,
+  ): Promise<Expectations<PromiseLike<Awaited<T>>>>
+
+  /**
+   * Expects the value to be a _rejected_ {@link PromiseLike}, and further
+   * asserts the rejection reason with an {@link AssertionFunction}.
+   *
+   * Negation: {@link Expectations.toBeResolved `toBeResolved(...)`}
+   */
+  toBeRejected(
+    assertion: AssertionFunction,
+  ): Promise<Expectations<PromiseLike<Awaited<T>>>>
+
+  toBeRejected(
+      assertionOrMatcher?: AssertionFunction | Matcher,
+  ): Promise<Expectations> {
     return Promise.resolve()
         .then(() => {
           this.toHaveProperty('then', (assert) => assert.toBeA('function'))
@@ -42,7 +65,11 @@ export class AsyncExpectations<T = unknown> extends Expectations<T> {
         })
         .then(([ settlement ]) => {
           if (settlement.status === 'rejected') {
-            if (assertion) assertion(new Expectations(settlement.reason, this.remarks))
+            if (isMatcher(assertionOrMatcher)) {
+              assertionOrMatcher.expect(settlement.reason)
+            } else if (assertionOrMatcher) {
+              assertionOrMatcher(new Expectations(settlement.reason, this.remarks))
+            }
             return this as Expectations<any>
           }
 
@@ -112,15 +139,35 @@ export class AsyncExpectations<T = unknown> extends Expectations<T> {
   /* ------------------------------------------------------------------------ */
 
   /**
-   * Expects the value to be a _resolved_ {@link PromiseLike}, and (if
-   * specified) further asserts the resolved result with an
-   * {@link AssertionFunction}.
+   * Expects the value to be a _resolved_ {@link PromiseLike}.
+   *
+   * Negation: {@link Expectations.toBeRejected `toBeRejected(...)`}
+   */
+  toBeResolved(): Promise<Expectations<PromiseLike<Awaited<T>>>>
+
+  /**
+   * Expects the value to be a _resolved_ {@link PromiseLike}, and further
+   * validates the resolved result with a {@link Matcher}.
+   *
+   * Negation: {@link Expectations.toBeRejected `toBeRejected(...)`}
+   */
+  toBeResolved<Match extends Matcher>(
+    matcher: Match,
+  ): Promise<Expectations<PromiseLike<InferMatcher<unknown, Match>>>>
+
+  /**
+   * Expects the value to be a _resolved_ {@link PromiseLike}, and further
+   * asserts the resolved result with an {@link AssertionFunction}.
    *
    * Negation: {@link Expectations.toBeRejected `toBeRejected(...)`}
    */
   toBeResolved<Assert extends AssertionFunction<Awaited<T>>>(
-      assertion?: Assert,
-  ): Promise<Expectations<PromiseLike<AssertedType<Awaited<T>, Assert>>>> {
+    assertion: Assert,
+  ): Promise<Expectations<PromiseLike<AssertedType<Awaited<T>, Assert>>>>
+
+  toBeResolved(
+      assertion?: AssertionFunction | Matcher,
+  ): Promise<Expectations> {
     return Promise.resolve()
         .then(() => {
           this.toHaveProperty('then', (assert) => assert.toBeA('function'))
@@ -128,7 +175,11 @@ export class AsyncExpectations<T = unknown> extends Expectations<T> {
         })
         .then(([ settlement ]) => {
           if (settlement.status === 'fulfilled') {
-            if (assertion) assertion(new Expectations(settlement.value, this.remarks))
+            if (isMatcher(assertion)) {
+              assertion.expect(settlement.value)
+            } else if (assertion) {
+              assertion(new Expectations(settlement.value, this.remarks))
+            }
             return this as Expectations<any>
           }
 

--- a/workspaces/expect5/src/expectation/expect.ts
+++ b/workspaces/expect5/src/expectation/expect.ts
@@ -1,9 +1,9 @@
 import { AsyncExpectations } from './async'
-import { Matchers } from './matchers'
+import { Matcher } from './matchers'
 
 export type { AsyncExpectations } from './async'
 export type { Expectations, NegativeExpectations } from './expectations'
-export type { Matchers, NegativeMatchers } from './matchers'
+export type { Matcher as Matchers, NegativeMatchers } from './matchers'
 
 /* ========================================================================== *
  * EXPECT FUNCTION                                                            *
@@ -12,7 +12,7 @@ export type { Matchers, NegativeMatchers } from './matchers'
 /** The `expect` function exposing expectations and matchers */
 export type Expect = {
   <T = unknown>(value: T, remarks?: string): AsyncExpectations<T>
-} & Omit<Matchers, 'expect'>
+} & Omit<Matcher, 'expect'>
 
 /** The `expect` function exposing expectations and matchers */
 export const expect: Expect = ((value: any, remarks?: string) => {
@@ -20,13 +20,13 @@ export const expect: Expect = ((value: any, remarks?: string) => {
 }) as Expect
 
 /* Inject all our matchers constructors in the `expect` function */
-for (const key of Object.getOwnPropertyNames(Matchers.prototype)) {
+for (const key of Object.getOwnPropertyNames(Matcher.prototype)) {
   if (! key.startsWith('to')) continue
 
-  const matcher = (...args: any[]): any => ((new Matchers() as any)[key](...args))
+  const matcher = (...args: any[]): any => ((new Matcher() as any)[key](...args))
   Object.defineProperty(matcher, 'name', { value: key })
   Object.defineProperty(expect, key, { value: matcher })
 }
 
 /* Inject the negative matcher constructor in the `expect` function */
-Object.defineProperty(expect, 'not', { get: () => new Matchers().not })
+Object.defineProperty(expect, 'not', { get: () => new Matcher().not })

--- a/workspaces/expect5/src/expectation/expectations.ts
+++ b/workspaces/expect5/src/expectation/expectations.ts
@@ -1,6 +1,6 @@
 import { diff, type Diff } from './diff'
 import { toInclude, toMatchContents } from './include'
-import { type Matchers } from './matchers'
+import { type Matcher } from './matchers'
 import {
   ExpectationError,
   isMatcher,
@@ -29,7 +29,7 @@ export type AssertedType<T, F extends AssertionFunction<any>, R = ReturnType<F>>
     T // returns something else (void), use T
 
 export type InferMatchers<T> =
-  T extends Matchers<infer V> ? V :
+  T extends Matcher<infer V> ? V :
   T extends Record<any, any> ? { [ k in keyof T ] : InferMatchers<T[k]> } :
   T
 
@@ -445,17 +445,17 @@ export class Expectations<T = unknown> {
 
   /**
    * Expects the value to have the specified _property_ and (if specified)
-   * further validates its value with a {@link Matchers}.
+   * further validates its value with a {@link Matcher}.
    *
    * Negation: {@link NegativeExpectations.toHaveProperty `not.toHaveProperty(...)`}
    */
   toHaveProperty<
     Prop extends string | number | symbol,
-    Matcher extends Matchers,
+    Match extends Matcher,
   >(
     property: Prop,
-    matcher?: Matcher,
-  ): Expectations<T & { [keyt in Prop] : InferMatchers<Matcher> }>
+    matcher?: Match,
+  ): Expectations<T & { [keyt in Prop] : InferMatchers<Match> }>
 
   /**
    * Expects the value to have the specified _property_ and (if specified)
@@ -473,7 +473,7 @@ export class Expectations<T = unknown> {
 
   toHaveProperty(
       property: string | number | symbol,
-      assertionOrMatcher?: AssertionFunction | Matchers,
+      assertionOrMatcher?: AssertionFunction | Matcher,
   ): Expectations {
     this.toBeDefined()
 
@@ -618,11 +618,11 @@ export class Expectations<T = unknown> {
 
   /**
    * Expects the value to be a `function` throwing, and (if specified) further
-   * further validates its value with a {@link Matchers}.
+   * further validates its value with a {@link Matcher}.
    *
    * Negation: {@link NegativeExpectations.toThrow `not.toThrow()`}
    */
-  toThrow(matcher?: Matchers): Expectations<() => any>
+  toThrow(matcher?: Matcher): Expectations<() => any>
 
   /**
    * Expects the value to be a `function` throwing, and (if specified) further
@@ -633,7 +633,7 @@ export class Expectations<T = unknown> {
   toThrow(assert?: AssertionFunction): Expectations<() => any>
 
   toThrow(
-      assertionOrMatcher?: AssertionFunction | Matchers,
+      assertionOrMatcher?: AssertionFunction | Matcher,
   ): Expectations<() => any> {
     const func = this.toBeA('function')
 

--- a/workspaces/expect5/src/expectation/expectations.ts
+++ b/workspaces/expect5/src/expectation/expectations.ts
@@ -87,8 +87,7 @@ export class Expectations<T = unknown> {
    * ------------------------------------------------------------------------ */
 
   /**
-   * Expects the value to be of the specified _extended_ {@link TypeName type},
-   * and (if specified) further validates it with a {@link Matcher}.
+   * Expects the value to be of the specified _extended_ {@link TypeName type}.
    *
    * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
    */
@@ -96,7 +95,7 @@ export class Expectations<T = unknown> {
 
   /**
    * Expects the value to be of the specified _extended_ {@link TypeName type},
-   * and (if specified) further validates it with a {@link Matcher}.
+   * and further validates it with a {@link Matcher}.
    *
    * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
    */
@@ -111,7 +110,7 @@ export class Expectations<T = unknown> {
 
   /**
    * Expects the value to be of the specified _extended_ {@link TypeName type},
-   * and (if specified) further asserts it with an {@link AssertionFunction}.
+   * and further asserts it with an {@link AssertionFunction}.
    *
    * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
    */
@@ -665,20 +664,27 @@ export class Expectations<T = unknown> {
   /* ------------------------------------------------------------------------ */
 
   /**
-   * Expects the value to be a `function` throwing, and (if specified) further
-   * further validates its value with a {@link Matcher}.
+   * Expects the value to be a `function` throwing.
    *
    * Negation: {@link NegativeExpectations.toThrow `not.toThrow()`}
    */
-  toThrow(matcher?: Matcher): Expectations<() => any>
+  toThrow(matcher: Matcher): Expectations<() => any>
 
   /**
-   * Expects the value to be a `function` throwing, and (if specified) further
-   * asserts the thrown value with an {@link AssertionFunction}.
+   * Expects the value to be a `function` throwing, and further validates the
+   * thrown value with a {@link Matcher}.
    *
    * Negation: {@link NegativeExpectations.toThrow `not.toThrow()`}
    */
-  toThrow(assert?: AssertionFunction): Expectations<() => any>
+  toThrow(matcher: Matcher): Expectations<() => any>
+
+  /**
+   * Expects the value to be a `function` throwing, and further asserts the
+   * thrown value with an {@link AssertionFunction}.
+   *
+   * Negation: {@link NegativeExpectations.toThrow `not.toThrow()`}
+   */
+  toThrow(assert: AssertionFunction): Expectations<() => any>
 
   toThrow(
       assertionOrMatcher?: AssertionFunction | Matcher,

--- a/workspaces/expect5/src/expectation/expectations.ts
+++ b/workspaces/expect5/src/expectation/expectations.ts
@@ -445,7 +445,7 @@ export class Expectations<T = unknown> {
 
   /**
    * Expects the value to have the specified _property_ and (if specified)
-   * validates its value with a {@link Matchers}.
+   * further validates its value with a {@link Matchers}.
    *
    * Negation: {@link NegativeExpectations.toHaveProperty `not.toHaveProperty(...)`}
    */
@@ -618,11 +618,23 @@ export class Expectations<T = unknown> {
 
   /**
    * Expects the value to be a `function` throwing, and (if specified) further
+   * further validates its value with a {@link Matchers}.
+   *
+   * Negation: {@link NegativeExpectations.toThrow `not.toThrow()`}
+   */
+  toThrow(matcher?: Matchers): Expectations<() => any>
+
+  /**
+   * Expects the value to be a `function` throwing, and (if specified) further
    * asserts the thrown value with an {@link AssertionFunction}.
    *
    * Negation: {@link NegativeExpectations.toThrow `not.toThrow()`}
    */
-  toThrow(assert?: AssertionFunction): Expectations<() => any> {
+  toThrow(assert?: AssertionFunction): Expectations<() => any>
+
+  toThrow(
+      assertionOrMatcher?: AssertionFunction | Matchers,
+  ): Expectations<() => any> {
     const func = this.toBeA('function')
 
     let passed = false
@@ -630,7 +642,11 @@ export class Expectations<T = unknown> {
       func.value()
       passed = true
     } catch (thrown) {
-      if (assert) assert(new Expectations(thrown, this.remarks))
+      if (isMatcher(assertionOrMatcher)) {
+        assertionOrMatcher.expect(thrown)
+      } else if (assertionOrMatcher) {
+        assertionOrMatcher(new Expectations(thrown, this.remarks))
+      }
     }
 
     if (passed) this._fail('to throw')

--- a/workspaces/expect5/src/expectation/matchers.ts
+++ b/workspaces/expect5/src/expectation/matchers.ts
@@ -366,6 +366,15 @@ export class Matcher<T = unknown> {
   /* ------------------------------------------------------------------------ */
 
   /**
+   * Expects the value to have the specified _property_.
+   *
+   * Negation: {@link NegativeExpectations.toHaveProperty `not.toHaveProperty(...)`}
+   */
+  toHaveProperty<Prop extends string | number | symbol>(
+    property: Prop,
+  ): Matcher<T & { [keyt in Prop] : unknown }>
+
+  /**
    * Expects the value to have the specified _property_ and (if specified)
    * validates its value with a {@link Matcher}.
    *
@@ -376,7 +385,7 @@ export class Matcher<T = unknown> {
     Match extends Matcher,
   >(
     property: Prop,
-    matcher?: Match,
+    matcher: Match,
   ): Matcher<T & { [keyt in Prop] : InferMatcher<unknown, Match> }>
 
   /**
@@ -390,7 +399,7 @@ export class Matcher<T = unknown> {
     Assert extends AssertionFunction,
   >(
     property: Prop,
-    assertion?: Assert,
+    assertion: Assert,
   ): Matcher<T & { [keyt in Prop] : AssertedType<unknown, Assert> }>
 
   toHaveProperty(

--- a/workspaces/expect5/src/expectation/matchers.ts
+++ b/workspaces/expect5/src/expectation/matchers.ts
@@ -12,19 +12,19 @@ import {
   type TypeName,
 } from './types'
 
-type Matcher = (expectations: Expectations) => Expectations
-type NegativeMatcher = (expectations: NegativeExpectations) => Expectations
+type PositiveMatcherFunction = (expectations: Expectations) => Expectations
+type NegativeMatcherFunction = (expectations: NegativeExpectations) => Expectations
 
 /* ========================================================================== *
- * EXPECTATIONS                                                               *
+ * MATCHERS                                                                   *
  * ========================================================================== */
 
-export class Matchers<T = unknown> {
-  private readonly _matchers: Matcher[]
+export class Matcher<T = unknown> {
+  private readonly _matchers: PositiveMatcherFunction[]
   readonly not: NegativeMatchers<T>
 
   constructor() {
-    const matchers: Matcher[] = []
+    const matchers: PositiveMatcherFunction[] = []
     this.not = new NegativeMatchers(this, matchers)
     this._matchers = matchers
   }
@@ -37,8 +37,8 @@ export class Matchers<T = unknown> {
     return expectations.value as T
   }
 
-  private _push(matcher: Matcher): Matchers<any> {
-    const matchers = new Matchers()
+  private _push(matcher: PositiveMatcherFunction): Matcher<any> {
+    const matchers = new Matcher()
     matchers._matchers.push(...this._matchers, matcher)
     return matchers
   }
@@ -64,7 +64,7 @@ export class Matchers<T = unknown> {
   >(
       type: Name,
       assertion?: Assert,
-  ): Matchers<AssertedType<Mapped, Assert>> {
+  ): Matcher<AssertedType<Mapped, Assert>> {
     return this._push((e) => e.toBeA(type, assertion as AssertionFunction))
   }
 
@@ -76,7 +76,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeCloseTo `not.toBeCloseTo(...)`}
    */
-  toBeCloseTo(value: number, delta: number): Matchers<number>
+  toBeCloseTo(value: number, delta: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` within a given +/- _delta_ range of the
@@ -84,7 +84,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeCloseTo `not.toBeCloseTo(...)`}
    */
-  toBeCloseTo(value: bigint, delta: bigint): Matchers<bigint>
+  toBeCloseTo(value: bigint, delta: bigint): Matcher<bigint>
 
   /**
    * Expects the value to be a `number` or `bigint` within a given +/- _delta_
@@ -95,7 +95,7 @@ export class Matchers<T = unknown> {
   toBeCloseTo(
       value: number | bigint,
       delta: number | bigint,
-  ): Matchers {
+  ): Matcher {
     return this._push((e) => e.toBeCloseTo(value as number, delta as number))
   }
 
@@ -106,7 +106,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeDefined `not.toBeDefined()`}
    */
-  toBeDefined(): Matchers<T> {
+  toBeDefined(): Matcher<T> {
     return this._push((e) => e.toBeDefined())
   }
 
@@ -121,7 +121,7 @@ export class Matchers<T = unknown> {
    */
   toBeError(
     message?: string | RegExp
-  ): Matchers<Error>
+  ): Matcher<Error>
 
   /**
    * Expect the value to be an instance of {@link Error} and further asserts
@@ -133,12 +133,12 @@ export class Matchers<T = unknown> {
   toBeError<Class extends Constructor<Error>>(
     constructor: Class,
     message?: string | RegExp,
-  ): Matchers<InstanceType<Class>>
+  ): Matcher<InstanceType<Class>>
 
   toBeError(
       constructorOrMessage?: string | RegExp | Constructor,
       maybeMessage?: string | RegExp,
-  ): Matchers {
+  ): Matcher {
     const [ constructor, message ] =
     typeof constructorOrMessage === 'function' ?
       [ constructorOrMessage, maybeMessage ] :
@@ -149,7 +149,7 @@ export class Matchers<T = unknown> {
   /* ------------------------------------------------------------------------ */
 
   /** Expects the value strictly equal to `false`. */
-  toBeFalse(): Matchers<false> {
+  toBeFalse(): Matcher<false> {
     return this._push((e) => e.toBeFalse())
   }
 
@@ -158,9 +158,9 @@ export class Matchers<T = unknown> {
   /**
    * Expects the value to be _falsy_ (zero, empty string, `false`, ...).
    *
-   * Negation: {@link Matchers.toBeTruthy `toBeTruthy()`}
+   * Negation: {@link Matcher.toBeTruthy `toBeTruthy()`}
    */
-  toBeFalsy(): Matchers<T> {
+  toBeFalsy(): Matcher<T> {
     return this._push((e) => e.toBeFalsy())
   }
 
@@ -170,19 +170,19 @@ export class Matchers<T = unknown> {
    * Expects the value to be a `number` greater than the specified* expected
    * value.
    *
-   * Negation: {@link Matchers.toBeLessThanOrEqual `toBeLessThanOrEqual(...)`}
+   * Negation: {@link Matcher.toBeLessThanOrEqual `toBeLessThanOrEqual(...)`}
    */
-  toBeGreaterThan(value: number): Matchers<number>
+  toBeGreaterThan(value: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` greater than the specified expected
    * value.
    *
-   * Negation: {@link Matchers.toBeLessThanOrEqual `toBeLessThanOrEqual(...)`}
+   * Negation: {@link Matcher.toBeLessThanOrEqual `toBeLessThanOrEqual(...)`}
    */
-  toBeGreaterThan(value: bigint): Matchers<bigint>
+  toBeGreaterThan(value: bigint): Matcher<bigint>
 
-  toBeGreaterThan(value: number | bigint): Matchers {
+  toBeGreaterThan(value: number | bigint): Matcher {
     return this._push((e) => e.toBeGreaterThan(value as number))
   }
 
@@ -192,19 +192,19 @@ export class Matchers<T = unknown> {
    * Expects the value to be a `number` greater than or equal to the specified
    * expected value.
    *
-   * Negation: {@link Matchers.toBeLessThan `toBeLessThan(...)`}
+   * Negation: {@link Matcher.toBeLessThan `toBeLessThan(...)`}
    */
-  toBeGreaterThanOrEqual(value: number): Matchers<number>
+  toBeGreaterThanOrEqual(value: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` greater than or equal to the specified
    * expected value.
    *
-   * Negation: {@link Matchers.toBeLessThan `toBeLessThan(...)`}
+   * Negation: {@link Matcher.toBeLessThan `toBeLessThan(...)`}
    */
-  toBeGreaterThanOrEqual(value: bigint): Matchers<bigint>
+  toBeGreaterThanOrEqual(value: bigint): Matcher<bigint>
 
-  toBeGreaterThanOrEqual(value: number | bigint): Matchers {
+  toBeGreaterThanOrEqual(value: number | bigint): Matcher {
     return this._push((e) => e.toBeGreaterThanOrEqual(value as number))
   }
 
@@ -222,7 +222,7 @@ export class Matchers<T = unknown> {
   >(
       constructor: Class,
       assertion?: Assert,
-  ): Matchers<AssertedType<InstanceType<Class>, Assert>> {
+  ): Matcher<AssertedType<InstanceType<Class>, Assert>> {
     return this._push((e) => e.toBeInstanceOf(constructor, assertion as AssertionFunction))
   }
 
@@ -231,18 +231,18 @@ export class Matchers<T = unknown> {
   /**
    * Expects the value to be a `number` less than the specified expected value.
    *
-   * Negation: {@link Matchers.toBeGreaterThanOrEqual `toBeGreaterThanOrEqual(...)`}
+   * Negation: {@link Matcher.toBeGreaterThanOrEqual `toBeGreaterThanOrEqual(...)`}
    */
-  toBeLessThan(value: number): Matchers<number>
+  toBeLessThan(value: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` less than the specified expected value.
    *
-   * Negation: {@link Matchers.toBeGreaterThanOrEqual `toBeGreaterThanOrEqual(...)`}
+   * Negation: {@link Matcher.toBeGreaterThanOrEqual `toBeGreaterThanOrEqual(...)`}
    */
-  toBeLessThan(value: bigint): Matchers<bigint>
+  toBeLessThan(value: bigint): Matcher<bigint>
 
-  toBeLessThan(value: number | bigint): Matchers {
+  toBeLessThan(value: number | bigint): Matcher {
     return this._push((e) => e.toBeLessThan(value as number))
   }
 
@@ -252,19 +252,19 @@ export class Matchers<T = unknown> {
    * Expects the value to be a `number` less than or equal to* the specified
    * expected value.
    *
-   * Negation: {@link Matchers.toBeGreaterThan `toBeGreaterThan(...)`}
+   * Negation: {@link Matcher.toBeGreaterThan `toBeGreaterThan(...)`}
    */
-  toBeLessThanOrEqual(value: number): Matchers<number>
+  toBeLessThanOrEqual(value: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` less than or equal to the specified
    * expected value.
    *
-   * Negation: {@link Matchers.toBeGreaterThan `toBeGreaterThan(...)`}
+   * Negation: {@link Matcher.toBeGreaterThan `toBeGreaterThan(...)`}
    */
-  toBeLessThanOrEqual(value: bigint): Matchers<bigint>
+  toBeLessThanOrEqual(value: bigint): Matcher<bigint>
 
-  toBeLessThanOrEqual(value: number | bigint): Matchers {
+  toBeLessThanOrEqual(value: number | bigint): Matcher {
     return this._push((e) => e.toBeLessThanOrEqual(value as number))
   }
 
@@ -275,21 +275,21 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeNaN `not.toBeNaN()`}
    */
-  toBeNaN(): Matchers<number> {
+  toBeNaN(): Matcher<number> {
     return this._push((e) => e.toBeNaN())
   }
 
   /* ------------------------------------------------------------------------ */
 
   /** Expects the value to strictly equal `null`. */
-  toBeNull(): Matchers<null> {
+  toBeNull(): Matcher<null> {
     return this._push((e) => e.toBeNull())
   }
 
   /* ------------------------------------------------------------------------ */
 
   /** Expects the value to strictly equal `true`. */
-  toBeTrue(): Matchers<true> {
+  toBeTrue(): Matcher<true> {
     return this._push((e) => e.toBeTrue())
   }
 
@@ -298,16 +298,16 @@ export class Matchers<T = unknown> {
   /**
    * Expects the value to be _falsy_ (non-zero, non-empty string, ...).
    *
-   * Negation: {@link Matchers.toBeFalsy `toBeFalsy()`}
+   * Negation: {@link Matcher.toBeFalsy `toBeFalsy()`}
    */
-  toBeTruthy(): Matchers<T> {
+  toBeTruthy(): Matcher<T> {
     return this._push((e) => e.toBeTruthy())
   }
 
   /* ------------------------------------------------------------------------ */
 
   /** Expects the value to strictly equal `undefined`. */
-  toBeUndefined(): Matchers<undefined> {
+  toBeUndefined(): Matcher<undefined> {
     return this._push((e) => e.toBeUndefined())
   }
 
@@ -319,7 +319,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeWithinRange `not.toBeWithinRange(...)`}
    */
-  toBeWithinRange(min: number, max: number): Matchers<number>
+  toBeWithinRange(min: number, max: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` within the specified range where the
@@ -327,7 +327,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeWithinRange `not.toBeWithinRange(...)`}
    */
-  toBeWithinRange(min: bigint, max: bigint): Matchers<bigint>
+  toBeWithinRange(min: bigint, max: bigint): Matcher<bigint>
 
   /**
    * Expects the value to be a `number` or `bigint` within the specified range
@@ -335,7 +335,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toBeWithinRange `not.toBeWithinRange(...)`}
    */
-  toBeWithinRange( min: number | bigint, max: number | bigint): Matchers {
+  toBeWithinRange( min: number | bigint, max: number | bigint): Matcher {
     return this._push((e) => e.toBeWithinRange(min as number, max as number))
   }
 
@@ -346,7 +346,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toEqual `not.toEqual(...)`}
    */
-  toEqual<Type>(expected: Type): Matchers<InferMatchers<Type>> {
+  toEqual<Type>(expected: Type): Matcher<InferMatchers<Type>> {
     return this._push((e) => e.toEqual(expected))
   }
 
@@ -358,7 +358,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toHaveLength `not.toHaveLength(...)`}
    */
-  toHaveLength(length: number): Matchers<T & { length: number }> {
+  toHaveLength(length: number): Matcher<T & { length: number }> {
     return this._push((e) => e.toHaveLength(length))
   }
 
@@ -366,17 +366,17 @@ export class Matchers<T = unknown> {
 
   /**
    * Expects the value to have the specified _property_ and (if specified)
-   * validates its value with a {@link Matchers}.
+   * validates its value with a {@link Matcher}.
    *
    * Negation: {@link NegativeExpectations.toHaveProperty `not.toHaveProperty(...)`}
    */
   toHaveProperty<
     Prop extends string | number | symbol,
-    Matcher extends Matchers,
+    Match extends Matcher,
   >(
     property: Prop,
-    matcher?: Matcher,
-  ): Matchers<T & { [keyt in Prop] : InferMatchers<Matcher> }>
+    matcher?: Match,
+  ): Matcher<T & { [keyt in Prop] : InferMatchers<Match> }>
 
   /**
    * Expects the value to have the specified _property_ and (if specified)
@@ -390,12 +390,12 @@ export class Matchers<T = unknown> {
   >(
     property: Prop,
     assertion?: Assert,
-  ): Matchers<T & { [keyt in Prop] : AssertedType<unknown, Assert> }>
+  ): Matcher<T & { [keyt in Prop] : AssertedType<unknown, Assert> }>
 
   toHaveProperty(
       property: string | number | symbol,
-      assertionOrMatcher?: AssertionFunction | Matchers,
-  ): Matchers {
+      assertionOrMatcher?: AssertionFunction | Matcher,
+  ): Matcher {
     return this._push((e) => e.toHaveProperty(property, assertionOrMatcher as any))
   }
 
@@ -407,7 +407,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toHaveSize `not.toHaveSize(...)`}
    */
-  toHaveSize(size: number): Matchers<T & { size: number }> {
+  toHaveSize(size: number): Matcher<T & { size: number }> {
     return this._push((e) => e.toHaveSize(size))
   }
 
@@ -421,14 +421,14 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toInclude `not.toInclude(...)`}
    */
-  toInclude<P extends Record<string, any>>(properties: P): Matchers<T>
+  toInclude<P extends Record<string, any>>(properties: P): Matcher<T>
 
   /**
    * Expect the value to include _all_ mappings from the specified {@link Map}.
    *
    * Negation: {@link NegativeMatchers.toInclude `not.toInclude(...)`}
    */
-  toInclude(mappings: Map<any, any>): Matchers<T>
+  toInclude(mappings: Map<any, any>): Matcher<T>
 
   /**
    * Expect the value to be an {@link Iterable} object includind _all_ values
@@ -436,7 +436,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toInclude `not.toInclude(...)`}
    */
-  toInclude(entries: Set<any>): Matchers<T>
+  toInclude(entries: Set<any>): Matcher<T>
 
   /**
    * Expect the value to be an {@link Iterable} object includind _all_ values
@@ -444,11 +444,11 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toInclude `not.toInclude(...)`}
    */
-  toInclude(values: any[]): Matchers<T>
+  toInclude(values: any[]): Matcher<T>
 
   toInclude(
       contents: Record<string, any> | Map<any, any> | Set<any> | any[],
-  ): Matchers {
+  ): Matcher {
     return this._push((e) => e.toInclude(contents))
   }
 
@@ -460,9 +460,9 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toMatch `not.toMatch(...)`}
    */
-  toMatch<Matcher extends string | RegExp>(
-      matcher: Matcher,
-  ): Matchers<string> {
+  toMatch<Match extends string | RegExp>(
+      matcher: Match,
+  ): Matcher<string> {
     return this._push((e) => e.toMatch(matcher))
   }
 
@@ -472,15 +472,15 @@ export class Matchers<T = unknown> {
    * Expect the value to be an {@link Iterable} object includind _all_ values
    * (and only those values) from the specified _array_, in any order.
    */
-  toMatchContents(contents: any[]): Matchers<T>
+  toMatchContents(contents: any[]): Matcher<T>
 
   /**
    * Expect the value to be an {@link Iterable} object includind _all_ values
    * (and only those values) from the specified {@link Set}, in any order.
    */
-  toMatchContents(contents: Set<any>): Matchers<T>
+  toMatchContents(contents: Set<any>): Matcher<T>
 
-  toMatchContents(contents: any[] | Set<any>): Matchers {
+  toMatchContents(contents: any[] | Set<any>): Matcher {
     return this._push((e) => e.toMatchContents(contents))
   }
 
@@ -491,7 +491,7 @@ export class Matchers<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toStrictlyEqual `not.toStrictlyEqual(...)`}
    */
-  toStrictlyEqual<Type>(expected: Type): Matchers<Type> {
+  toStrictlyEqual<Type>(expected: Type): Matcher<Type> {
     return this._push((e) => e.toStrictlyEqual(expected))
   }
 }
@@ -502,11 +502,11 @@ export class Matchers<T = unknown> {
 
 export class NegativeMatchers<T = unknown> {
   constructor(
-      private readonly _instance: Matchers<T>,
-      private readonly _matchers: Matcher[],
+      private readonly _instance: Matcher<T>,
+      private readonly _matchers: PositiveMatcherFunction[],
   ) {}
 
-  private _push(matcher: NegativeMatcher): Matchers<any> {
+  private _push(matcher: NegativeMatcherFunction): Matcher<any> {
     this._matchers.push((expectations) => matcher(expectations.not))
     return this._instance
   }
@@ -517,9 +517,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value _**NOT**_ to be of the specified _extended_
    * {@link TypeName type}.
    *
-   * Negates: {@link Matchers.toBeA `toBeA(...)`}
+   * Negates: {@link Matcher.toBeA `toBeA(...)`}
    */
-  toBeA(type: TypeName): Matchers<T> {
+  toBeA(type: TypeName): Matcher<T> {
     return this._push((e) => e.toBeA(type))
   }
 
@@ -529,19 +529,19 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value to be a `number` _**OUTSIDE**_ of the given +/- _delta_
    * range of the specified expected value.
    *
-   * Negates: {@link Matchers.toBeCloseTo `toBeCloseTo(...)`}
+   * Negates: {@link Matcher.toBeCloseTo `toBeCloseTo(...)`}
    */
-  toBeCloseTo(value: number, delta: number): Matchers<number>
+  toBeCloseTo(value: number, delta: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` _**OUTSIDE**_ of the given +/- _delta_
    * range of the specified expected value.
    *
-   * Negates: {@link Matchers.toBeCloseTo `toBeCloseTo(...)`}
+   * Negates: {@link Matcher.toBeCloseTo `toBeCloseTo(...)`}
    */
-  toBeCloseTo(value: bigint, delta: bigint): Matchers<bigint>
+  toBeCloseTo(value: bigint, delta: bigint): Matcher<bigint>
 
-  toBeCloseTo(value: number | bigint, delta: number | bigint): Matchers {
+  toBeCloseTo(value: number | bigint, delta: number | bigint): Matcher {
     return this._push((e) => e.toBeCloseTo(value as number, delta as number))
   }
 
@@ -550,9 +550,9 @@ export class NegativeMatchers<T = unknown> {
   /**
    * Expects the value to be either `null` or `undefined`.
    *
-   * Negates: {@link Matchers.toBeDefined `toBeDefined()`}
+   * Negates: {@link Matcher.toBeDefined `toBeDefined()`}
    */
-  toBeDefined(): Matchers<null | undefined> {
+  toBeDefined(): Matcher<null | undefined> {
     return this._push((e) => e.toBeDefined())
   }
 
@@ -562,9 +562,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value _**NOT**_ to be an instance of the specified
    * {@link Constructor}.
    *
-   * Negates: {@link Matchers.toBeInstanceOf `toBeInstanceOf(...)`}
+   * Negates: {@link Matcher.toBeInstanceOf `toBeInstanceOf(...)`}
    */
-  toBeInstanceOf(constructor: Constructor): Matchers<T> {
+  toBeInstanceOf(constructor: Constructor): Matcher<T> {
     return this._push((e) => e.toBeInstanceOf(constructor))
   }
 
@@ -573,9 +573,9 @@ export class NegativeMatchers<T = unknown> {
   /**
    * Expects the value _**NOT**_ to be `NaN`.
    *
-   * Negates: {@link Matchers.toBeNaN `toBeNaN()`}
+   * Negates: {@link Matcher.toBeNaN `toBeNaN()`}
    */
-  toBeNaN(): Matchers<number> {
+  toBeNaN(): Matcher<number> {
     return this._push((e) => e.toBeNaN())
   }
 
@@ -585,19 +585,19 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value to be a `number` _**OUTSIDE**_ of the specified range
    * where minimum and maximum values are inclusive.
    *
-   * Negates: {@link Matchers.toBeWithinRange `toBeWithinRange(...)`}
+   * Negates: {@link Matcher.toBeWithinRange `toBeWithinRange(...)`}
    */
-  toBeWithinRange(min: number, max: number): Matchers<number>
+  toBeWithinRange(min: number, max: number): Matcher<number>
 
   /**
    * Expects the value to be a `bigint` _**OUTSIDE**_ of the specified range
    * where minimum and maximum values are inclusive.
    *
-   * Negates: {@link Matchers.toBeWithinRange `toBeWithinRange(...)`}
+   * Negates: {@link Matcher.toBeWithinRange `toBeWithinRange(...)`}
    */
-  toBeWithinRange(min: bigint, max: bigint): Matchers<bigint>
+  toBeWithinRange(min: bigint, max: bigint): Matcher<bigint>
 
-  toBeWithinRange(min: number | bigint, max: number | bigint): Matchers {
+  toBeWithinRange(min: number | bigint, max: number | bigint): Matcher {
     return this._push((e) => e.toBeWithinRange(min as number, max as number))
   }
 
@@ -607,9 +607,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value _**NOT**_ to be _deep equal to_ the specified expected
    * one.
    *
-   * Negates: {@link Matchers.toEqual `toEqual(...)`}
+   * Negates: {@link Matcher.toEqual `toEqual(...)`}
    */
-  toEqual(expected: any): Matchers<T> {
+  toEqual(expected: any): Matcher<T> {
     return this._push((e) => e.toEqual(expected))
   }
 
@@ -619,9 +619,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value to have a `number` _property_ `length` _different_ from
    * the specified expected value.
    *
-   * Negates: {@link Matchers.toHaveLength `toHaveLength(...)`}
+   * Negates: {@link Matcher.toHaveLength `toHaveLength(...)`}
    */
-  toHaveLength(length: number): Matchers<T & { length: number }> {
+  toHaveLength(length: number): Matcher<T & { length: number }> {
     return this._push((e) => e.toHaveLength(length))
   }
 
@@ -630,9 +630,9 @@ export class NegativeMatchers<T = unknown> {
   /**
    * Expects the value _**NOT**_ to have the specified _property_.
    *
-   * Negates: {@link Matchers.toHaveProperty `toHaveProperty(...)`}
+   * Negates: {@link Matcher.toHaveProperty `toHaveProperty(...)`}
    */
-  toHaveProperty(property: string | number | symbol): Matchers<T> {
+  toHaveProperty(property: string | number | symbol): Matcher<T> {
     return this._push((e) => e.toHaveProperty(property))
   }
 
@@ -642,9 +642,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value to have a `number` _property_ `size` _different_ from
    * the specified expected value.
    *
-   * Negates: {@link Matchers.toHaveSize `toHaveSize(...)`}
+   * Negates: {@link Matcher.toHaveSize `toHaveSize(...)`}
    */
-  toHaveSize(size: number): Matchers<T & { size: number }> {
+  toHaveSize(size: number): Matcher<T & { size: number }> {
     return this._push((e) => e.toHaveSize(size))
   }
 
@@ -657,37 +657,37 @@ export class NegativeMatchers<T = unknown> {
    * If the object being expected is a {@link Map}, the properties specified
    * here will be treated as _mappings_ for said {@link Map}.
    *
-   * Negates: {@link Matchers.toInclude `toInclude(...)`}
+   * Negates: {@link Matcher.toInclude `toInclude(...)`}
    */
-  toInclude<P extends Record<string, any>>(properties: P): Matchers<T>
+  toInclude<P extends Record<string, any>>(properties: P): Matcher<T>
 
   /**
    * Expect the value to include _none_ of the mappings from the specified
    * {@link Map}.
    *
-   * Negates: {@link Matchers.toInclude `toInclude(...)`}
+   * Negates: {@link Matcher.toInclude `toInclude(...)`}
    */
-  toInclude(mappings: Map<any, any>): Matchers<T>
+  toInclude(mappings: Map<any, any>): Matcher<T>
 
   /**
    * Expect the value to be an {@link Iterable} object includind _none_ of the
    * values from the specified {@link Set}.
    *
-   * Negates: {@link Matchers.toInclude `toInclude(...)`}
+   * Negates: {@link Matcher.toInclude `toInclude(...)`}
    */
-  toInclude(entries: Set<any>): Matchers<T>
+  toInclude(entries: Set<any>): Matcher<T>
 
   /**
    * Expect the value to be an {@link Iterable} object includind _none_ of the
    * values from the specified _array_.
    *
-   * Negates: {@link Matchers.toInclude `toInclude(...)`}
+   * Negates: {@link Matcher.toInclude `toInclude(...)`}
    */
-  toInclude(values: any[]): Matchers<T>
+  toInclude(values: any[]): Matcher<T>
 
   toInclude(
       contents: Record<string, any> | Map<any, any> | Set<any> | any[],
-  ): Matchers {
+  ): Matcher {
     return this._push((e) => e.toInclude(contents))
   }
 
@@ -697,9 +697,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value to be a `string` _**NOT MATCHING**_ the specified
    * sub-`string` or {@link RegExp}.
    *
-   * Negates: {@link Matchers.toMatch `toMatch(...)`}
+   * Negates: {@link Matcher.toMatch `toMatch(...)`}
    */
-  toMatch(matcher: string | RegExp): Matchers<string> {
+  toMatch(matcher: string | RegExp): Matcher<string> {
     return this._push((e) => e.toMatch(matcher))
   }
 
@@ -709,9 +709,9 @@ export class NegativeMatchers<T = unknown> {
    * Expects the value _**NOT**_ to be _strictly equal to_ the specified
    * expected one.
    *
-   * Negates: {@link Matchers.toStrictlyEqual `toStrictlyEqual(...)`}
+   * Negates: {@link Matcher.toStrictlyEqual `toStrictlyEqual(...)`}
    */
-  toStrictlyEqual(expected: any): Matchers<T> {
+  toStrictlyEqual(expected: any): Matcher<T> {
     return this._push((e) => e.toStrictlyEqual(expected))
   }
 }

--- a/workspaces/expect5/src/expectation/matchers.ts
+++ b/workspaces/expect5/src/expectation/matchers.ts
@@ -54,19 +54,47 @@ export class Matcher<T = unknown> {
 
   /**
    * Expects the value to be of the specified _extended_ {@link TypeName type},
-   * and (if specified) further asserts it with an {@link AssertionFunction}.
+   * and (if specified) further validates it with a {@link Matcher}.
    *
-   * Negation: {@link NegativeMatchers.toBeA `not.toBeA(...)`}
+   * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
    */
+  toBeA<Name extends TypeName>(type: Name): Matcher<TypeMappings[Name]>
+
+  /**
+    * Expects the value to be of the specified _extended_ {@link TypeName type},
+    * and (if specified) further validates it with a {@link Matcher}.
+    *
+    * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
+    */
+  toBeA<
+    Name extends TypeName,
+    Mapped extends TypeMappings[Name],
+    Match extends Matcher,
+  >(
+    type: Name,
+    matcher: Match,
+  ): Matcher<InferMatcher<Mapped, Match>>
+
+  /**
+    * Expects the value to be of the specified _extended_ {@link TypeName type},
+    * and (if specified) further asserts it with an {@link AssertionFunction}.
+    *
+    * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
+    */
   toBeA<
     Name extends TypeName,
     Mapped extends TypeMappings[Name],
     Assert extends AssertionFunction<Mapped>,
   >(
-      type: Name,
-      assertion?: Assert,
-  ): Matcher<AssertedType<Mapped, Assert>> {
-    return this._push((e) => e.toBeA(type, assertion as AssertionFunction))
+    type: Name,
+    assertion: Assert,
+  ): Matcher<AssertedType<Mapped, Assert>>
+
+  toBeA(
+      type: TypeName,
+      assertionOrMatcher?: AssertionFunction | Matcher,
+  ): Matcher {
+    return this._push((e) => e.toBeA(type, assertionOrMatcher as any))
   }
 
   /* ------------------------------------------------------------------------ */

--- a/workspaces/expect5/src/expectation/matchers.ts
+++ b/workspaces/expect5/src/expectation/matchers.ts
@@ -366,6 +366,20 @@ export class Matchers<T = unknown> {
 
   /**
    * Expects the value to have the specified _property_ and (if specified)
+   * validates its value with a {@link Matchers}.
+   *
+   * Negation: {@link NegativeExpectations.toHaveProperty `not.toHaveProperty(...)`}
+   */
+  toHaveProperty<
+    Prop extends string | number | symbol,
+    Matcher extends Matchers,
+  >(
+    property: Prop,
+    matcher?: Matcher,
+  ): Matchers<T & { [keyt in Prop] : InferMatchers<Matcher> }>
+
+  /**
+   * Expects the value to have the specified _property_ and (if specified)
    * further asserts its value with an {@link AssertionFunction}.
    *
    * Negation: {@link NegativeMatchers.toHaveProperty `not.toHaveProperty(...)`}
@@ -374,10 +388,15 @@ export class Matchers<T = unknown> {
     Prop extends string | number | symbol,
     Assert extends AssertionFunction,
   >(
-      property: Prop,
-      assertion?: Assert,
-  ): Matchers<T & { [keyt in Prop] : AssertedType<unknown, Assert> }> {
-    return this._push((e) => e.toHaveProperty(property, assertion))
+    property: Prop,
+    assertion?: Assert,
+  ): Matchers<T & { [keyt in Prop] : AssertedType<unknown, Assert> }>
+
+  toHaveProperty(
+      property: string | number | symbol,
+      assertionOrMatcher?: AssertionFunction | Matchers,
+  ): Matchers {
+    return this._push((e) => e.toHaveProperty(property, assertionOrMatcher as any))
   }
 
   /* ------------------------------------------------------------------------ */

--- a/workspaces/expect5/src/expectation/matchers.ts
+++ b/workspaces/expect5/src/expectation/matchers.ts
@@ -3,7 +3,8 @@ import {
   type AssertedType,
   type AssertionFunction,
   type NegativeExpectations,
-  type InferMatchers,
+  type InferMatcher,
+  type InferToEqual,
 } from './expectations'
 import {
   matcherMarker,
@@ -346,7 +347,7 @@ export class Matcher<T = unknown> {
    *
    * Negation: {@link NegativeMatchers.toEqual `not.toEqual(...)`}
    */
-  toEqual<Type>(expected: Type): Matcher<InferMatchers<Type>> {
+  toEqual<Type>(expected: Type): Matcher<InferToEqual<Type>> {
     return this._push((e) => e.toEqual(expected))
   }
 
@@ -376,7 +377,7 @@ export class Matcher<T = unknown> {
   >(
     property: Prop,
     matcher?: Match,
-  ): Matcher<T & { [keyt in Prop] : InferMatchers<Match> }>
+  ): Matcher<T & { [keyt in Prop] : InferMatcher<unknown, Match> }>
 
   /**
    * Expects the value to have the specified _property_ and (if specified)

--- a/workspaces/expect5/src/expectation/matchers.ts
+++ b/workspaces/expect5/src/expectation/matchers.ts
@@ -53,8 +53,7 @@ export class Matcher<T = unknown> {
    * ------------------------------------------------------------------------ */
 
   /**
-   * Expects the value to be of the specified _extended_ {@link TypeName type},
-   * and (if specified) further validates it with a {@link Matcher}.
+   * Expects the value to be of the specified _extended_ {@link TypeName type}.
    *
    * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
    */
@@ -62,7 +61,7 @@ export class Matcher<T = unknown> {
 
   /**
     * Expects the value to be of the specified _extended_ {@link TypeName type},
-    * and (if specified) further validates it with a {@link Matcher}.
+    * and further validates it with a {@link Matcher}.
     *
     * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
     */
@@ -77,7 +76,7 @@ export class Matcher<T = unknown> {
 
   /**
     * Expects the value to be of the specified _extended_ {@link TypeName type},
-    * and (if specified) further asserts it with an {@link AssertionFunction}.
+    * and further asserts it with an {@link AssertionFunction}.
     *
     * Negation: {@link NegativeExpectations.toBeA `not.toBeA(...)`}
     */
@@ -403,8 +402,8 @@ export class Matcher<T = unknown> {
   ): Matcher<T & { [keyt in Prop] : unknown }>
 
   /**
-   * Expects the value to have the specified _property_ and (if specified)
-   * validates its value with a {@link Matcher}.
+   * Expects the value to have the specified _property_ and validates its value
+   * with a {@link Matcher}.
    *
    * Negation: {@link NegativeExpectations.toHaveProperty `not.toHaveProperty(...)`}
    */
@@ -417,8 +416,8 @@ export class Matcher<T = unknown> {
   ): Matcher<T & { [keyt in Prop] : InferMatcher<unknown, Match> }>
 
   /**
-   * Expects the value to have the specified _property_ and (if specified)
-   * further asserts its value with an {@link AssertionFunction}.
+   * Expects the value to have the specified _property_ and further asserts
+   * its value with an {@link AssertionFunction}.
    *
    * Negation: {@link NegativeMatchers.toHaveProperty `not.toHaveProperty(...)`}
    */

--- a/workspaces/expect5/src/expectation/types.ts
+++ b/workspaces/expect5/src/expectation/types.ts
@@ -1,6 +1,6 @@
 import { type Diff } from './diff'
 import { type Expectations } from './expectations'
-import { type Matchers } from './matchers'
+import { type Matcher } from './matchers'
 
 /* ========================================================================== *
  * INTERNAL TYPES FOR EXPECTATIONS                                            *
@@ -194,7 +194,7 @@ export function prefixType(type: TypeName): string {
 
 export const matcherMarker = Symbol.for('plugjs:expect5:types:Matcher')
 
-export function isMatcher(what: any): what is Matchers {
+export function isMatcher(what: any): what is Matcher {
   return what && what[matcherMarker] === matcherMarker
 }
 

--- a/workspaces/expect5/src/test.ts
+++ b/workspaces/expect5/src/test.ts
@@ -244,9 +244,10 @@ function dumpProps(log: Logger, pad: number, error: Error): void {
         'showDiff', // chai
         'stack', // error
       ].includes(k))
+      .filter((k) => !(error[k as keyof typeof error] === null))
+      .filter((k) => !(error[k as keyof typeof error] === undefined))
       .forEach((k) => {
         const value = error[k as keyof typeof error]
-        if (value === undefined) return // we can safely ignore those
         if ((k === 'code') && (value === 'ERR_ASSERTION')) return
         const details = typeof value === 'string' ? value : stringifyValue(value)
         log.error($gry(`${k}:`.padStart(pad - 1)), $ylw(details))

--- a/workspaces/expect5/src/test.ts
+++ b/workspaces/expect5/src/test.ts
@@ -6,7 +6,7 @@ import { AssertionError } from 'node:assert'
 import { BuildFailure } from '@plugjs/plug'
 import { assert } from '@plugjs/plug/asserts'
 import { type Files } from '@plugjs/plug/files'
-import { $blu, $grn, $gry, $ms, $red, $wht, $ylw, ERROR, NOTICE, WARN, log, type Logger } from '@plugjs/plug/logging'
+import { $blu, $grn, $gry, $ms, $red, $wht, $ylw, ERROR, NOTICE, WARN, log, type Logger, $p } from '@plugjs/plug/logging'
 import { type Context, type PipeParameters, type Plug } from '@plugjs/plug/pipe'
 
 import * as setup from './execution/setup'
@@ -63,7 +63,11 @@ export class Test implements Plug<void> {
 
     // Create our _root_ Suite
     const suite = new Suite(undefined, '', async () => {
-      for (const file of files.absolutePaths()) await import(file)
+      let count = 0
+      for (const file of files.absolutePaths()) {
+        log.debug('Importing', $p(file), 'in suite', $gry(`(${++ count}/${files.length})`))
+        await import(file)
+      }
     })
 
     // Setup our suite counts

--- a/workspaces/expect5/src/test.ts
+++ b/workspaces/expect5/src/test.ts
@@ -246,6 +246,7 @@ function dumpProps(log: Logger, pad: number, error: Error): void {
       ].includes(k))
       .forEach((k) => {
         const value = error[k as keyof typeof error]
+        if (value === undefined) return // we can safely ignore those
         if ((k === 'code') && (value === 'ERR_ASSERTION')) return
         const details = typeof value === 'string' ? value : stringifyValue(value)
         log.error($gry(`${k}:`.padStart(pad - 1)), $ylw(details))

--- a/workspaces/expect5/test/22-expectation-basic.test.ts
+++ b/workspaces/expect5/test/22-expectation-basic.test.ts
@@ -229,6 +229,7 @@ describe('Basic Expectations', () => {
     const s2 = Symbol()
 
     expectPass(() => expect('foo').toHaveProperty('length'))
+    expectPass(() => expect('foo').toHaveProperty('length', expect.toStrictlyEqual(3)))
     expectPass(() => expect('foo').toHaveProperty('length', (assert) => assert.toEqual(3)))
     expectPass(() => expect([ 0 ]).toHaveProperty(0))
     expectPass(() => expect({ [s]: 'foo' }).toHaveProperty(s))

--- a/workspaces/expect5/test/22-expectation-basic.test.ts
+++ b/workspaces/expect5/test/22-expectation-basic.test.ts
@@ -6,8 +6,16 @@ import { expectFail, expectPass } from './utils'
 describe('Basic Expectations', () => {
   it('should expect "toBeA(...)"', () => {
     expectPass(() => expect('foo').toBeA('string'))
+    expectPass(() => expect('foo').toBeA('string', expect.toStrictlyEqual('foo')))
     expectPass(() => expect('foo').toBeA('string', (assert) => assert.toStrictlyEqual('foo')))
+
     expectFail(() => expect('foo').toBeA('number'), 'Expected "foo" to be a <number>')
+    expectFail(() => expect('foo').toBeA('string', expect.toStrictlyEqual('bar')),
+        'Expected "foo" to strictly equal "bar"', {
+          diff: true,
+          value: 'foo',
+          expected: 'bar',
+        })
     expectFail(() => expect('foo').toBeA('string', (assert) => assert.toStrictlyEqual('bar')),
         'Expected "foo" to strictly equal "bar"', {
           diff: true,

--- a/workspaces/expect5/test/22-expectation-basic.test.ts
+++ b/workspaces/expect5/test/22-expectation-basic.test.ts
@@ -103,11 +103,38 @@ describe('Basic Expectations', () => {
   })
 
   it('should expect "toBeInstanceOf(...)"', () => {
-    const error = new TypeError()
+    const error = new TypeError('some message')
 
     expectPass(() => expect(error).toBeInstanceOf(Error))
     expectPass(() => expect(error).toBeInstanceOf(TypeError))
+    expectPass(() => expect(error).toBeInstanceOf(TypeError, expect.toHaveProperty('message', expect.toStrictlyEqual('some message'))))
+    expectPass(() => expect(error).toBeInstanceOf(TypeError, (assert) => assert.toHaveProperty('message', expect.toStrictlyEqual('some message'))))
+
     expectFail(() => expect(error).toBeInstanceOf(SyntaxError), 'Expected [TypeError] to be an instance of [SyntaxError]')
+    expectFail(() => expect(error).toBeInstanceOf(TypeError, expect.toHaveProperty('message', expect.toStrictlyEqual('a different message'))),
+        'Expected property ["message"] of [TypeError] ("some message") to strictly equal "a different message"', {
+          diff: true,
+          value: error,
+          props: {
+            message: {
+              diff: true,
+              value: 'some message',
+              expected: 'a different message',
+            },
+          },
+        })
+    expectFail(() => expect(error).toBeInstanceOf(TypeError, (assert) => assert.toHaveProperty('message', expect.toStrictlyEqual('a different message'))),
+        'Expected property ["message"] of [TypeError] ("some message") to strictly equal "a different message"', {
+          diff: true,
+          value: error,
+          props: {
+            message: {
+              diff: true,
+              value: 'some message',
+              expected: 'a different message',
+            },
+          },
+        })
 
     expectFail(() => expect(error).not.toBeInstanceOf(Error), 'Expected [TypeError] not to be an instance of [Error]')
     expectFail(() => expect(error).not.toBeInstanceOf(TypeError), 'Expected [TypeError] not to be an instance of [TypeError]')

--- a/workspaces/expect5/test/23-expectation-throwing.test.ts
+++ b/workspaces/expect5/test/23-expectation-throwing.test.ts
@@ -10,18 +10,33 @@ describe('Throwing Expectations', () => {
       throw error
     }
 
+    // no parameters
     expectPass(() => expect(throwing).toThrow())
     expectFail(() => expect(() => {}).toThrow(), 'Expected <function> to throw')
 
+    // with expectations matcher
+    expectPass(() => expect(throwing).toThrow(expect.toStrictlyEqual(error)))
+    expectFail(() => expect(throwing).toThrow(expect.toStrictlyEqual('foo')),
+        'Expected [SyntaxError] to strictly equal "foo"', {
+          diff: true,
+          value: error,
+          expected: 'foo',
+        })
+
+    // with assertion function
     let asserted: any = undefined
     expectPass(() => expect(throwing).toThrow((e) => void (asserted = e.value)))
     assert.strictEqual(asserted, error)
 
     // even when throwing undefined
-    expectPass(() => expect(() => {
+    function throwUndefined(): never {
       // eslint-disable-next-line no-throw-literal
       throw undefined
-    }).toThrow((assert) => void (asserted = assert.value)))
+    }
+
+    asserted = 'bogus!'
+    expectPass(() => expect(throwUndefined).toThrow(expect.toBeUndefined()))
+    expectPass(() => expect(throwUndefined).toThrow((assert) => void (asserted = assert.value)))
     assert.strictEqual(asserted, undefined)
   })
 

--- a/workspaces/expect5/test/26-expectation-async.test.ts
+++ b/workspaces/expect5/test/26-expectation-async.test.ts
@@ -8,20 +8,28 @@ describe('Asynchronous Expectations', () => {
     const error = new Error('foo')
     const expectation = expect(Promise.reject(error))
 
-    // should be simply resolved...
+    // should be simply rejected...
     const promise = expectation.toBeRejected()
     assert(promise instanceof Promise)
     assert.strictEqual(await promise, expectation)
 
     // should also pass assertions through
     let assertions: any = undefined
-    await expect(Promise.reject(error)).toBeRejected((assert) => void (assertions = assert))
+    await expectation.toBeRejected((assert) => void (assertions = assert))
     assert.strictEqual(assertions.value, error)
 
     // rejections
     await assert.rejects(expect(Promise.resolve('foo')).toBeRejected(), (reason) => {
       assert(reason instanceof ExpectationError)
       assert.strictEqual(reason.message, 'Expected [Promise] to be rejected')
+      return true
+    })
+
+    // should be rejected and match the error _precisely_...
+    await expectation.toBeRejected(expect.toStrictlyEqual(error))
+    await assert.rejects(expectation.toBeRejected(expect.toStrictlyEqual('foo')), (reason) => {
+      assert(reason instanceof ExpectationError)
+      assert.strictEqual(reason.message, 'Expected [Error] to strictly equal "foo"')
       return true
     })
   })
@@ -104,13 +112,21 @@ describe('Asynchronous Expectations', () => {
 
     // should also pass assertions through
     let assertions: any = undefined
-    await expect(Promise.resolve('foo')).toBeResolved((assert) => void (assertions = assert))
+    await expectation.toBeResolved((assert) => void (assertions = assert))
     assert.strictEqual(assertions.value, 'foo')
 
     // rejections
     await assert.rejects(expect(Promise.reject(new Error('foo'))).toBeResolved(), (reason) => {
       assert(reason instanceof ExpectationError)
       assert.strictEqual(reason.message, 'Expected [Promise] to be resolved')
+      return true
+    })
+
+    // should be resolved and match the result _precisely_...
+    await expectation.toBeResolved(expect.toStrictlyEqual('foo'))
+    await assert.rejects(expectation.toBeResolved(expect.toStrictlyEqual('bar')), (reason) => {
+      assert(reason instanceof ExpectationError)
+      assert.strictEqual(reason.message, 'Expected "foo" to strictly equal "bar"')
       return true
     })
   })

--- a/workspaces/expect5/test/29-expectation-matchers.test.ts
+++ b/workspaces/expect5/test/29-expectation-matchers.test.ts
@@ -71,6 +71,18 @@ describe('Expectation Matchers', () => {
     })
     expectFail(() => expect.toHaveLength(0).expect('foo'), 'Expected "foo" to have length 0')
     expectFail(() => expect.toHaveProperty('a').expect({ b: 'foo' }), 'Expected [Object] to have property "a"')
+    expectFail(() => expect.toHaveProperty('b', expect.toStrictlyEqual('bar')).expect({ b: 'foo' }),
+        'Expected property ["b"] of [Object] ("foo") to strictly equal "bar"', {
+          diff: true,
+          value: { b: 'foo' },
+          props: {
+            b: {
+              diff: true,
+              value: 'foo',
+              expected: 'bar',
+            },
+          },
+        })
     expectFail(() => expect.toHaveSize(2).expect(new Set([ 'foo' ])), 'Expected [Set (1)] to have size 2')
     expectFail(() => expect.toMatch(/^foo$/i).expect('bar'), 'Expected "bar" to match /^foo$/i')
     expectFail(() => expect.toStrictlyEqual('foo').expect('bar'), 'Expected "bar" to strictly equal "foo"', {

--- a/workspaces/expect5/test/29-expectation-matchers.test.ts
+++ b/workspaces/expect5/test/29-expectation-matchers.test.ts
@@ -18,6 +18,8 @@ describe('Expectation Matchers', () => {
     expectPass(() => expect.toEqual({ a: 'foo' }).expect({ a: 'foo' }))
     expectPass(() => expect.toHaveLength(3).expect('foo'))
     expectPass(() => expect.toHaveProperty('a').expect({ a: 'foo' }))
+    expectPass(() => expect.toHaveProperty('a', (a) => a.toBeA('string')).expect({ a: 'foo' }))
+    expectPass(() => expect.toHaveProperty('a', expect.toBeA('string')).expect({ a: 'foo' }))
     expectPass(() => expect.toHaveSize(1).expect(new Set([ 'foo' ])))
     expectPass(() => expect.toMatch(/^foo$/i).expect('FOO'))
     expectPass(() => expect.toStrictlyEqual('foo').expect('foo'))

--- a/workspaces/expect5/test/50-plug.test.ts
+++ b/workspaces/expect5/test/50-plug.test.ts
@@ -30,30 +30,15 @@ describe('Expect5 Plug', async () => {
   })
 
   it('should fail a suite with errors', async () => {
-    await expect(merge([ find('errors.ts', { directory } ) ]).plug(new Test()))
+    await expect(merge([ find('errors*.ts', { directory, ignore: 'errors*-nodiff.ts' } ) ])
+        .plug(new Test()))
         .toBeRejectedWithError(BuildFailure, '')
   })
 
-  it('should fail a suite with chai assertion errors', async () => {
-    await expect(merge([ find('errors-chai.ts', { directory } ) ]).plug(new Test()))
+  it('should fail a suite with errors (no diffs)', async () => {
+    await expect(merge([ find('errors*-nodiff.ts', { directory } ) ])
+        .plug(new Test({ genericErrorDiffs: false })))
         .toBeRejectedWithError(BuildFailure, '')
-  })
-
-  it('should fail a suite with chai assertion errors (no diffs)', async () => {
-    await expect(merge([ find('errors-chai-nodiff.ts', { directory } ) ]).plug(new Test({
-      genericErrorDiffs: false,
-    }))).toBeRejectedWithError(BuildFailure, '')
-  })
-
-  it('should fail a suite with node assertion errors', async () => {
-    await expect(merge([ find('errors-assert.ts', { directory } ) ]).plug(new Test()))
-        .toBeRejectedWithError(BuildFailure, '')
-  })
-
-  it('should fail a suite with node assertion errors (no diffs)', async () => {
-    await expect(merge([ find('errors-assert-nodiff.ts', { directory } ) ]).plug(new Test({
-      genericErrorDiffs: false,
-    }))).toBeRejectedWithError(BuildFailure, '')
   })
 
   it('should fail a suite with only specs', async () => {

--- a/workspaces/expect5/test/data/errors-assert-nodiff.ts
+++ b/workspaces/expect5/test/data/errors-assert-nodiff.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert'
 
-describe('A test suite (error-asserts)', () => {
+describe('A test suite (error-asserts-nodiff)', () => {
   it('should throw a node assertion error (1)', () => {
     assert.deepEqual({ foo: 'bar' }, { foo: 'baz' })
   })

--- a/workspaces/expect5/test/data/errors-chai-nodiff.ts
+++ b/workspaces/expect5/test/data/errors-chai-nodiff.ts
@@ -1,6 +1,6 @@
 import { expect as chai } from 'chai'
 
-describe('A test suite (errors-chai)', () => {
+describe('A test suite (errors-chai-nodiff)', () => {
   it('should throw a chai assertion error (1)', () => {
     chai({ foo: 'bar' }).to.eql({ foo: 'baz' })
   })

--- a/workspaces/expect5/test/data/errors.ts
+++ b/workspaces/expect5/test/data/errors.ts
@@ -8,6 +8,8 @@ describe('A test suite (errors)', () => {
     error.str = 'test'
     error.num = 12345
     error.sym = Symbol.for('foobar')
+    error.null = null
+    error.none = undefined
     throw error
   })
 

--- a/workspaces/plug/package.json
+++ b/workspaces/plug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/plug",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/workspaces/tsd/package.json
+++ b/workspaces/tsd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/tsd",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -33,7 +33,7 @@
     "tsd": "^0.28.1"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.6"
+    "@plugjs/plug": "0.4.7"
   },
   "files": [
     "*.md",

--- a/workspaces/typescript/package.json
+++ b/workspaces/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/typescript",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -33,7 +33,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.6"
+    "@plugjs/plug": "0.4.7"
   },
   "files": [
     "*.md",

--- a/workspaces/zip/package.json
+++ b/workspaces/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/zip",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -38,7 +38,7 @@
     "yauzl": "^2.10.0"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.6"
+    "@plugjs/plug": "0.4.7"
   },
   "files": [
     "*.md",


### PR DESCRIPTION
Better interaction between `Expectations` and `Matcher`, whereas a `Matcher` can be used in lieu of any `AssertionFunction`.