### PR TITLE
Print matcher

### DIFF
--- a/workspaces/expect5/src/expectation/print.ts
+++ b/workspaces/expect5/src/expectation/print.ts
@@ -8,7 +8,7 @@ import {
   type MissingValueDiff,
   type ObjectDiff,
 } from './diff'
-import { stringifyValue } from './types'
+import { isMatcher, stringifyValue } from './types'
 
 /* ========================================================================== *
  * CONSTANT LABELS FOR PRINTING                                               *
@@ -31,6 +31,7 @@ const _hellip = $gry('\u2026')
 
 const _error = `${_opnPar}${$gry($und('error'))}${_clsPar}`
 const _string = `${_opnPar}${$gry($und('string'))}${_clsPar}`
+const _matcher = $gry('\u2026 matcher \u2026')
 const _extraProps = $gry('\u2026 extra props \u2026')
 const _diffHeader = `${$wht('Differences')} ${_opnPar}${$red('actual')}${_slash}${$grn('expected')}${_slash}${$ylw('errors')}${_clsPar}:`
 
@@ -268,6 +269,11 @@ function dumpAndContinue(
   // primitives just get dumped
   if ((value === null) || (typeof value !== 'object')) {
     return `${prefix}${color(stringify(value))}${suffix}`
+  }
+
+  // matchers are a very special value...
+  if (isMatcher(value)) {
+    return `${prefix}${_matcher}${suffix}`
   }
 
   // check for circular dependencies

--- a/workspaces/tsd/test/test.ts
+++ b/workspaces/tsd/test/test.ts
@@ -8,23 +8,23 @@ describe('Tsd Plug', () => {
   it('should succeed with only passing tests', async () => {
     await find('**/passing.test-d.ts', { directory: dataDir })
         .plug(new Tsd({ cwd: dataDir }))
-  })
+  }, 10_000)
 
   it('should fail including failing tests', async () => {
     await expect(find('**/*.test-d.ts', { directory: dataDir })
         .plug(new Tsd({ cwd: dataDir, typingsFile: `${dataDir}/index.d.ts` })))
         .toBeRejectedWithError(BuildFailure)
-  })
+  }, 10_000)
 
   it('should fail with an incorrect typings file', async () => {
     await expect(find('**/*.test-d.ts', { directory: dataDir })
         .plug(new Tsd({ cwd: dataDir, typingsFile: `${dataDir}/does-not-exist.d.ts` })))
         .toBeRejectedWithError(Error, /The type definition `does-not-exist.d.ts` does not exist/)
-  })
+  }, 10_000)
 
   it('should install the "tsd" plug', async () => {
     expect(merge([]).tsd).toBeUndefined()
     await import('../src/index')
     expect(merge([]).tsd).toBeA('function')
-  })
+  }, 10_000)
 })


### PR DESCRIPTION
Fix printing of `Matcher` values without expanding all their properties.