### PR TITLE
No build marker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plugjs/monorepo",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plugjs/monorepo",
-      "version": "0.4.27",
+      "version": "0.4.28",
       "workspaces": [
         "workspaces/cov8",
         "workspaces/eslint",
@@ -569,9 +569,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
-      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.7.0.tgz",
+      "integrity": "sha512-+HencqxU7CFJnQb7IKtuNBqS6Yx3Tz4kOL8BJXo+JyeiBm5MEX6pO8onXDkjrkCRlfYXS1Axro15ZjVFe9YgsA==",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -637,9 +637,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -787,9 +787,9 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.5.tgz",
-      "integrity": "sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA=="
+      "version": "18.17.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.8.tgz",
+      "integrity": "sha512-Av/7MqX/iNKwT9Tr60V85NqMnsmh8ilfJoBlIVibkXfitk9Q22D9Y5mSpm+FvG5DET7EbVfB40bOiLzKgYFgPw=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -828,17 +828,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
-      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
+      "integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/type-utils": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/type-utils": "6.4.1",
+        "@typescript-eslint/utils": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -864,16 +864,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
-      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
+      "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -893,14 +893,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
-      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
+      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0"
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -911,14 +911,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
-      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
+      "integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/utils": "6.4.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -939,9 +939,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
-      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -953,14 +953,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
-      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
+      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/visitor-keys": "6.4.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -981,18 +981,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.4.1",
+        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.4.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1007,13 +1007,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
-      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
+      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/types": "6.4.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1537,9 +1537,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.0.tgz",
-      "integrity": "sha512-B8s/n+ZluN7sxj9eUf7/pRFERX0r5bnFA2dCaLHy2ZeaQEAz0k+ZZkFWRFHJAqxfxQDx6KLv9LeIki7cFdwW+Q==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
+      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.6",
@@ -1913,13 +1913,12 @@
         "eslint-import-resolver-node": "^0.3.7",
         "eslint-module-utils": "^2.8.0",
         "has": "^1.0.3",
-        "is-core-module": "^2.12.1",
+        "is-core-module": "^2.13.0",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.6",
         "object.groupby": "^1.0.0",
         "object.values": "^1.1.6",
-        "resolve": "^1.22.3",
         "semver": "^6.3.1",
         "tsconfig-paths": "^3.14.2"
       },
@@ -2841,23 +2840,23 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jest-diff": {
-      "version": "29.6.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.2.tgz",
-      "integrity": "sha512-t+ST7CB9GX5F2xKwhwCf0TAR17uNDiaPTZnVymP9lw0lssa9vG+AFyDZoeIHStU3WowFFwT+ky+er0WVl2yGhA==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.3.tgz",
+      "integrity": "sha512-3sw+AdWnwH9sSNohMRKA7JiYUJSRr/WS6+sEFfBuhxU5V5GlEVKfvUn8JuMHE0wqKowemR1C2aHy8VtXbaV8dQ==",
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.4.3",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.2"
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.6.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3429,11 +3428,11 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.6.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
-      "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.3.tgz",
+      "integrity": "sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==",
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -4022,9 +4021,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.1.tgz",
-      "integrity": "sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -4304,7 +4303,7 @@
     },
     "workspaces/cov8": {
       "name": "@plugjs/cov8",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.22.10",
@@ -4316,12 +4315,12 @@
         "cov8": "dist/cli.mjs"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.26"
+        "@plugjs/plug": "0.4.27"
       }
     },
     "workspaces/eslint": {
       "name": "@plugjs/eslint",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "eslint": "^8.47.0"
@@ -4330,12 +4329,12 @@
         "@types/eslint": "^8.44.2"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.26"
+        "@plugjs/plug": "0.4.27"
       }
     },
     "workspaces/expect5": {
       "name": "@plugjs/expect5",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "bin": {
         "expect5": "dist/cli.mjs"
@@ -4345,12 +4344,12 @@
         "chai": "^4.3.7"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.26"
+        "@plugjs/plug": "0.4.27"
       }
     },
     "workspaces/plug": {
       "name": "@plugjs/plug",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@plugjs/tsrun": "^0.4.19",
@@ -4367,29 +4366,29 @@
     },
     "workspaces/tsd": {
       "name": "@plugjs/tsd",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "tsd": "^0.28.1"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.26"
+        "@plugjs/plug": "0.4.27"
       }
     },
     "workspaces/typescript": {
       "name": "@plugjs/typescript",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "typescript": "^5.1.6"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.26"
+        "@plugjs/plug": "0.4.27"
       }
     },
     "workspaces/zip": {
       "name": "@plugjs/zip",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "license": "Apache-2.0",
       "dependencies": {
         "yazl": "^2.5.1"
@@ -4400,7 +4399,7 @@
         "yauzl": "^2.10.0"
       },
       "peerDependencies": {
-        "@plugjs/plug": "0.4.26"
+        "@plugjs/plug": "0.4.27"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plugjs/monorepo",
   "private": true,
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "workspaces": [
     "workspaces/cov8",

--- a/test-d/00-plug.test-d.ts
+++ b/test-d/00-plug.test-d.ts
@@ -1,6 +1,5 @@
-import { printType, expectType, expectAssignable, expectError } from 'tsd'
-import { build, find, invokeTasks } from '@plugjs/plug'
-import { type Files, type Pipe, buildMarker } from '@plugjs/plug'
+import { build, find, invokeTasks, type Files, type Pipe } from '@plugjs/plug'
+import { expectAssignable, expectError, expectType, printType } from 'tsd'
 
 printType('__file_marker__')
 
@@ -28,7 +27,6 @@ const tasks = build({
     expectType<() => Pipe>(this.task_b)
     expectType<() => Pipe>(this.task_c)
 
-    // expectError(this[buildMarker]) // ts7053 unsupported
     expectError(this.missing)
 
     return await find('')
@@ -43,7 +41,6 @@ expectAssignable<{
   readonly task_a:() => Promise<undefined>,
   readonly task_b:() => Promise<Files>,
   readonly task_c:() => Promise<Files>,
-  [buildMarker]: (tasks: string[], props?: Record<string, string | undefined> | undefined) => Promise<void>
 }>(tasks)
 
 expectType<string>(tasks.prop_a)
@@ -57,14 +54,8 @@ expectType<Promise<undefined>>(tasks.task_a())
 expectType<Promise<Files>>(tasks.task_b())
 expectType<Promise<Files>>(tasks.task_c())
 
-expectType<(
-tasks: readonly string[],
-props?: Record<string, string | undefined> | undefined,
-) => Promise<void>>(tasks[buildMarker])
-
 expectError(tasks.prop_a = 'foo')
 expectError(tasks.task_a = async (): Promise<void> => {} )
-expectError(tasks[buildMarker] = async (): Promise<void> => {} )
 expectError(tasks.missing)
 
 expectType<Promise<void>>(invokeTasks(tasks, [ 'task_a', 'task_b', 'task_c' ], { prop_a: '', prop_b: '' }))

--- a/workspaces/cov8/package.json
+++ b/workspaces/cov8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/cov8",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -39,7 +39,7 @@
     "source-map": "^0.7.4"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.27"
+    "@plugjs/plug": "0.4.28"
   },
   "files": [
     "*.md",

--- a/workspaces/eslint/package.json
+++ b/workspaces/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/eslint",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -36,7 +36,7 @@
     "@types/eslint": "^8.44.2"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.27"
+    "@plugjs/plug": "0.4.28"
   },
   "files": [
     "*.md",

--- a/workspaces/expect5/package.json
+++ b/workspaces/expect5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/expect5",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -47,7 +47,7 @@
     "chai": "^4.3.7"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.27"
+    "@plugjs/plug": "0.4.28"
   },
   "files": [
     "*.md",

--- a/workspaces/plug/package.json
+++ b/workspaces/plug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/plug",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/workspaces/plug/src/build.ts
+++ b/workspaces/plug/src/build.ts
@@ -4,28 +4,35 @@ import { $gry, $ms, $p, $t, getLogger, logOptions } from './logging'
 import { Context, ContextPromises, PipeImpl } from './pipe'
 import { findCaller } from './utils/caller'
 import { getSingleton } from './utils/singleton'
-import { buildMarker } from './types'
 
 import type { Pipe } from './index'
 import type { AbsolutePath } from './paths'
 import type {
   Build,
-  BuildProps,
   BuildDef,
+  BuildProps,
+  BuildTasks,
+  Props,
   Result,
   State,
   Task,
-  TaskDef,
-  ThisBuild,
-  Props,
   TaskCall,
-  BuildTasks,
+  TaskDef,
   Tasks,
+  ThisBuild,
 } from './types'
 
 /* ========================================================================== *
  * INTERNAL UTILITIES                                                         *
  * ========================================================================== */
+
+/**
+ * Symbol indicating that an object is a {@link Build}.
+ *
+ * In a compiled {@link Build} this symbol will be associated with a function
+ * taking an array of strings (task names) and record of props to override
+ */
+const buildMarker = Symbol.for('plugjs:plug:types:Build')
 
 /** Symbol indicating that an object is a {@link TaskCall} */
 const taskCallMarker = Symbol.for('plugjs:plug:types:TaskCall')
@@ -254,7 +261,7 @@ export function invokeTasks<B extends Build>(
     props?: BuildProps<B>,
 ): Promise<void> {
   if (isBuild(build)) {
-    return build[buildMarker](tasks, props)
+    return (build as any)[buildMarker](tasks, props)
   } else {
     throw new TypeError('Invalid build instance')
   }

--- a/workspaces/plug/src/types.ts
+++ b/workspaces/plug/src/types.ts
@@ -129,17 +129,17 @@ export type ThisBuild<D extends BuildDef> = {
  * In a compiled {@link Build} this symbol will be associated with a function
  * taking an array of strings (task names) and record of props to override
  */
-export const buildMarker = Symbol.for('plugjs:plug:types:Build')
+// export const buildMarker = Symbol.for('plugjs:plug:types:Build')
 
 /**
  * The {@link Build} type represents the collection of {@link Task}s
  * and _properties_ compiled from a {@link BuildDef | build definition}.
  */
 export type Build<D extends BuildDef = BuildDef> = Props<D> & Tasks<D> & {
-  readonly [buildMarker]: (
-    tasks: readonly string[],
-    props?: Record<string, string | undefined>,
-  ) => Promise<void>
+  // readonly [buildMarker]: (
+  //   tasks: readonly string[],
+  //   props?: Record<string, string | undefined>,
+  // ) => Promise<void>
 }
 
 /** A type identifying all _task names_ in a {@link Build}. */

--- a/workspaces/plug/src/types.ts
+++ b/workspaces/plug/src/types.ts
@@ -124,24 +124,10 @@ export type ThisBuild<D extends BuildDef> = {
 }
 
 /**
- * Symbol indicating that an object is a {@link Build}.
- *
- * In a compiled {@link Build} this symbol will be associated with a function
- * taking an array of strings (task names) and record of props to override
- */
-// export const buildMarker = Symbol.for('plugjs:plug:types:Build')
-
-/**
  * The {@link Build} type represents the collection of {@link Task}s
  * and _properties_ compiled from a {@link BuildDef | build definition}.
  */
-export type Build<D extends BuildDef = BuildDef> = Props<D> & Tasks<D> & {
-  // readonly [buildMarker]: (
-  //   tasks: readonly string[],
-  //   props?: Record<string, string | undefined>,
-  // ) => Promise<void>
-}
-
+export type Build<D extends BuildDef = BuildDef> = Props<D> & Tasks<D>
 /** A type identifying all _task names_ in a {@link Build}. */
 export type BuildTasks<B extends Build> = string & keyof {
   [ name in keyof B as B[name] extends Function ? name : never ] : any

--- a/workspaces/tsd/package.json
+++ b/workspaces/tsd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/tsd",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -33,7 +33,7 @@
     "tsd": "^0.28.1"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.27"
+    "@plugjs/plug": "0.4.28"
   },
   "files": [
     "*.md",

--- a/workspaces/typescript/package.json
+++ b/workspaces/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/typescript",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -33,7 +33,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.27"
+    "@plugjs/plug": "0.4.28"
   },
   "files": [
     "*.md",

--- a/workspaces/zip/package.json
+++ b/workspaces/zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plugjs/zip",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -38,7 +38,7 @@
     "yauzl": "^2.10.0"
   },
   "peerDependencies": {
-    "@plugjs/plug": "0.4.27"
+    "@plugjs/plug": "0.4.28"
   },
   "files": [
     "*.md",


### PR DESCRIPTION
The internal (named) symbol `buildMarker` can not be named, and creates issues when extending builds.

Simply internalize the symbol and don't expose it to the outside world...