### PR TITLE
fix(eslint): use https repository metadata

### DIFF
--- a/workspaces/eslint/package.json
+++ b/workspaces/eslint/package.json
@@ -42,7 +42,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/plugjs/plug.git"
+    "url": "git+https://github.com/plugjs/plug.git"
   },
   "keywords": [
     "build",


### PR DESCRIPTION
## Summary
- update @plugjs/eslint repository metadata to use HTTPS instead of SSH

## Validation
- confirmed package metadata now points to git+https://github.com/plugjs/plug.git
- git diff --check
- git ls-remote https://github.com/plugjs/plug.git HEAD
- pnpm dlx npm@11.13.0 ci --ignore-scripts
- pnpm dlx npm@11.13.0 --workspace @plugjs/eslint pack --dry-run
- pnpm dlx npm@11.13.0 run build